### PR TITLE
Add environment-aware configuration and SQLite storage for option scans

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -1,0 +1,43 @@
+watchlists:
+  default:
+    - AAPL
+    - MSFT
+    - NVDA
+    - TSLA
+    - SPY
+    - QQQ
+    - IWM
+    - AMD
+  growth:
+    - SHOP
+    - SNOW
+    - PLTR
+    - CRWD
+    - MDB
+scoring:
+  enabled:
+    - volume
+    - iv_rank
+    - liquidity
+    - risk_reward
+  weights:
+    volume: 1.0
+    iv_rank: 1.2
+    liquidity: 0.8
+    risk_reward: 1.5
+  score_bounds:
+    min: 0.0
+    max: 100.0
+adapter:
+  provider: yfinance
+  settings:
+    timeout: 30
+cache:
+  ttl_seconds: 900
+storage:
+  backend: sqlite
+  sqlite:
+    path: data/dev-options.db
+    pragmas:
+      journal_mode: WAL
+      synchronous: NORMAL

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,0 +1,40 @@
+watchlists:
+  default:
+    - SPY
+    - QQQ
+    - DIA
+    - IWM
+    - GLD
+  momentum:
+    - NVDA
+    - TSLA
+    - META
+    - AMD
+    - GOOGL
+scoring:
+  enabled:
+    - volume
+    - iv_rank
+    - liquidity
+    - risk_reward
+  weights:
+    volume: 1.1
+    iv_rank: 1.3
+    liquidity: 0.9
+    risk_reward: 1.7
+  score_bounds:
+    min: 10.0
+    max: 100.0
+adapter:
+  provider: polygon
+  settings:
+    retries: 3
+cache:
+  ttl_seconds: 300
+storage:
+  backend: sqlite
+  sqlite:
+    path: data/prod-options.db
+    pragmas:
+      journal_mode: WAL
+      synchronous: FULL

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,14 @@
+# Database migrations
+
+This project uses [Alembic](https://alembic.sqlalchemy.org/) for database migrations. The current
+storage layer relies on SQLite and manages its baseline schema automatically. Future schema changes
+can be tracked by creating revision files in `migrations/versions/` using the Alembic CLI.
+
+Example bootstrap command:
+
+```bash
+alembic revision -m "describe change"
+```
+
+The generated migration can then be edited to apply DDL updates for the `options`, `signals`, and
+`metadata` tables maintained by `SQLiteStorage`.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,53 @@
+"""Alembic environment stub for future migrations."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+if config.config_file_name is not None:  # pragma: no cover - configuration side effect
+    fileConfig(config.config_file_name)
+
+# Placeholder metadata object - SQLAlchemy models can be wired here in the future.
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = config.get_main_option("sqlalchemy.url", "sqlite:///data/options.db")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = context.config.attributes.get("connection")
+    if connectable is None:
+        from sqlalchemy import create_engine
+
+        connectable = create_engine(config.get_main_option("sqlalchemy.url", "sqlite:///data/options.db"))
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+def main() -> None:
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy>=1.10.0
 requests>=2.31.0
 beautifulsoup4>=4.12.0
 pydantic>=1.10.0,<2.0
+PyYAML>=6.0.0

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,4 +1,4 @@
-"""Configuration helpers for Python scripts."""
+"""Configuration helpers for Python scripts and services."""
 
 from __future__ import annotations
 
@@ -6,7 +6,9 @@ import os
 from functools import lru_cache
 from typing import Optional
 
-from .adapters import OptionsDataAdapter, create_adapter
+from src.adapters import OptionsDataAdapter, create_adapter
+
+from .loader import AppSettings, get_settings, reset_settings_cache
 
 DEFAULT_OPTIONS_PROVIDER = "yfinance"
 
@@ -33,7 +35,10 @@ def reset_options_data_adapter_cache() -> None:
 
 
 __all__ = [
+    "AppSettings",
     "DEFAULT_OPTIONS_PROVIDER",
     "get_options_data_adapter",
+    "get_settings",
+    "reset_settings_cache",
     "reset_options_data_adapter_cache",
 ]

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -1,0 +1,189 @@
+"""Environment aware configuration loader for the options scanner."""
+
+from __future__ import annotations
+
+import copy
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional
+
+import yaml
+from pydantic import BaseModel, Field, root_validator, validator
+
+from src.scoring.config import DEFAULT_SCORER_CONFIG
+
+DEFAULT_SETTINGS: Dict[str, Any] = {
+    "watchlists": {
+        "default": ["SPY", "QQQ"],
+    },
+    "scoring": copy.deepcopy(DEFAULT_SCORER_CONFIG),
+    "adapter": {
+        "provider": "yfinance",
+        "settings": {},
+    },
+    "cache": {
+        "ttl_seconds": 900,
+    },
+    "storage": {
+        "backend": "sqlite",
+        "sqlite": {
+            "path": "data/options.db",
+            "pragmas": {},
+        },
+    },
+}
+
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "config"
+ENVIRONMENT_VARIABLE = "APP_ENV"
+
+
+class ScoringSettings(BaseModel):
+    """Scoring configuration wrapper for the composite engine."""
+
+    enabled: List[str] = Field(default_factory=lambda: list(DEFAULT_SCORER_CONFIG.get("enabled", [])))
+    weights: Dict[str, float] = Field(default_factory=lambda: dict(DEFAULT_SCORER_CONFIG.get("weights", {})))
+    score_bounds: Dict[str, float] = Field(default_factory=lambda: dict(DEFAULT_SCORER_CONFIG.get("score_bounds", {})))
+    extra: Dict[str, Any] = Field(default_factory=dict)
+
+    class Config:
+        extra = "allow"
+
+    @root_validator(pre=True)
+    def _capture_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[override]
+        known_keys = {"enabled", "weights", "score_bounds", "extra"}
+        extras = {key: values[key] for key in list(values.keys()) if key not in known_keys}
+        merged_extra = dict(values.get("extra", {}))
+        merged_extra.update(extras)
+        for key in extras:
+            values.pop(key, None)
+        values["extra"] = merged_extra
+        return values
+
+    @validator("weights", pre=True)
+    def _coerce_weights(cls, value: Mapping[str, Any]) -> Dict[str, float]:  # type: ignore[override]
+        return {key: float(val) for key, val in dict(value or {}).items()}
+
+    def to_engine_config(self) -> Dict[str, Any]:
+        config = {
+            "enabled": list(self.enabled),
+            "weights": dict(self.weights),
+            "score_bounds": dict(self.score_bounds),
+        }
+        config.update(self.extra)
+        return config
+
+
+class AdapterSettings(BaseModel):
+    provider: str = "yfinance"
+    settings: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CacheSettings(BaseModel):
+    ttl_seconds: int = 900
+
+
+class SQLiteSettings(BaseModel):
+    path: str = "data/options.db"
+    pragmas: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StorageSettings(BaseModel):
+    backend: str = "sqlite"
+    sqlite: SQLiteSettings = Field(default_factory=SQLiteSettings)
+
+    def require_sqlite(self) -> SQLiteSettings:
+        if self.backend != "sqlite":
+            raise ValueError(f"Unsupported storage backend: {self.backend}")
+        return self.sqlite
+
+
+class AppSettings(BaseModel):
+    """Fully resolved application settings loaded from YAML."""
+
+    env: str
+    watchlists: Dict[str, List[str]]
+    scoring: ScoringSettings
+    adapter: AdapterSettings
+    cache: CacheSettings
+    storage: StorageSettings
+
+    class Config:
+        frozen = True
+
+    @validator("env")
+    def _normalize_env(cls, value: str) -> str:  # type: ignore[override]
+        return value.lower()
+
+    @validator("watchlists", pre=True)
+    def _coerce_watchlists(cls, value: Mapping[str, Any]) -> Dict[str, List[str]]:  # type: ignore[override]
+        return {key: list(items or []) for key, items in dict(value or {}).items()}
+
+    def get_watchlist(self, name: str = "default") -> List[str]:
+        return list(self.watchlists.get(name, []))
+
+    def scoring_dict(self) -> Dict[str, Any]:
+        return self.scoring.to_engine_config()
+
+
+def _deep_merge(base: MutableMapping[str, Any], overrides: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    for key, value in overrides.items():
+        if isinstance(value, Mapping):
+            existing = base.get(key)
+            if isinstance(existing, MutableMapping):
+                base[key] = _deep_merge(copy.deepcopy(existing), value)
+            else:
+                base[key] = copy.deepcopy(value)
+        else:
+            base[key] = copy.deepcopy(value)
+    return base
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"Configuration file {path} must contain a mapping at the root.")
+        return data
+
+
+def _build_settings(env: str) -> AppSettings:
+    config_path = CONFIG_DIR / f"{env}.yaml"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Configuration file for environment '{env}' not found at {config_path}")
+
+    merged = copy.deepcopy(DEFAULT_SETTINGS)
+    overrides = _load_yaml(config_path)
+    merged = _deep_merge(merged, overrides)
+    merged["env"] = env
+    return AppSettings.parse_obj(merged)
+
+
+@lru_cache(maxsize=None)
+def _cached_settings(env: str) -> AppSettings:
+    return _build_settings(env)
+
+
+def get_settings(env: Optional[str] = None) -> AppSettings:
+    """Load settings for the requested environment (default: APP_ENV or 'dev')."""
+
+    resolved_env = (env or os.getenv(ENVIRONMENT_VARIABLE, "dev")).strip().lower()
+    return _cached_settings(resolved_env)
+
+
+def reset_settings_cache() -> None:
+    """Clear the cached settings, primarily used during tests."""
+
+    _cached_settings.cache_clear()
+
+
+__all__ = [
+    "AppSettings",
+    "AdapterSettings",
+    "CacheSettings",
+    "ScoringSettings",
+    "SQLiteSettings",
+    "StorageSettings",
+    "get_settings",
+    "reset_settings_cache",
+]

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,13 @@
+"""Storage backends for persisting option scan results."""
+
+from .base import OptionSnapshot, RunMetadata, SignalSnapshot, Storage, StorageError
+from .sqlite import SQLiteStorage
+
+__all__ = [
+    "OptionSnapshot",
+    "RunMetadata",
+    "SignalSnapshot",
+    "SQLiteStorage",
+    "Storage",
+    "StorageError",
+]

--- a/src/storage/base.py
+++ b/src/storage/base.py
@@ -1,0 +1,84 @@
+"""Base definitions for storage backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+
+class StorageError(RuntimeError):
+    """Raised when a storage backend encounters an unrecoverable error."""
+
+
+@dataclass(frozen=True)
+class RunMetadata:
+    """Metadata describing a single execution of the scanning workflow."""
+
+    run_id: str
+    run_at: datetime
+    environment: Optional[str] = None
+    watchlist: Optional[str] = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OptionSnapshot:
+    """Snapshot of an option contract at scan time."""
+
+    symbol: str
+    option_type: str
+    expiration: str
+    strike: float
+    data: Mapping[str, Any]
+    contract_symbol: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SignalSnapshot:
+    """Snapshot of a generated signal and its computed score."""
+
+    symbol: str
+    option_type: str
+    score: float
+    data: Mapping[str, Any]
+    contract_symbol: Optional[str] = None
+
+
+class Storage(ABC):
+    """Abstract base class for persistence backends."""
+
+    @abstractmethod
+    def save_run(
+        self,
+        metadata: RunMetadata,
+        options: Sequence[OptionSnapshot],
+        signals: Sequence[SignalSnapshot],
+    ) -> None:
+        """Persist a full scan run to storage."""
+
+    @abstractmethod
+    def list_runs(self, limit: Optional[int] = None) -> List[RunMetadata]:
+        """Return stored run metadata sorted from newest to oldest."""
+
+    @abstractmethod
+    def get_metadata(self, run_id: str) -> Optional[RunMetadata]:
+        """Fetch metadata for a given run identifier."""
+
+    @abstractmethod
+    def get_options(self, run_id: str) -> List[OptionSnapshot]:
+        """Return option snapshots associated with a run."""
+
+    @abstractmethod
+    def get_signals(self, run_id: str) -> List[SignalSnapshot]:
+        """Return generated signals associated with a run."""
+
+
+__all__ = [
+    "OptionSnapshot",
+    "RunMetadata",
+    "SignalSnapshot",
+    "Storage",
+    "StorageError",
+]

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -1,0 +1,270 @@
+"""SQLite-backed storage implementation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from .base import OptionSnapshot, RunMetadata, SignalSnapshot, Storage, StorageError
+
+
+def _default_json_serializer(obj: Any) -> Any:
+    """Best-effort conversion for non-native JSON objects."""
+
+    try:
+        import numpy as np  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        np = None  # type: ignore
+
+    try:
+        import pandas as pd  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        pd = None  # type: ignore
+
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if np is not None and isinstance(obj, np.generic):  # type: ignore[attr-defined]
+        return obj.item()
+    if pd is not None and isinstance(obj, pd.Timestamp):  # type: ignore[attr-defined]
+        return obj.to_pydatetime().isoformat()
+    if hasattr(obj, "isoformat"):
+        try:
+            return obj.isoformat()
+        except Exception:  # pragma: no cover - best effort
+            return str(obj)
+    if hasattr(obj, "tolist"):
+        try:
+            return obj.tolist()
+        except Exception:  # pragma: no cover - best effort
+            return str(obj)
+    return str(obj)
+
+
+def _json_dumps(payload: Mapping[str, Any]) -> str:
+    return json.dumps(dict(payload), default=_default_json_serializer)
+
+
+def _json_loads(payload: str) -> Dict[str, Any]:
+    return json.loads(payload) if payload else {}
+
+
+def _ensure_parent_exists(path: Path) -> None:
+    if path.name == ":memory:":
+        return
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+class SQLiteStorage(Storage):
+    """Persist scan data using a lightweight SQLite database."""
+
+    def __init__(
+        self,
+        database: str | Path,
+        pragmas: Optional[Mapping[str, Any]] = None,
+        *,
+        uri: bool = False,
+    ) -> None:
+        self._database = str(database)
+        self._uri = uri
+        self._pragmas = dict(pragmas or {})
+        if not uri and self._database != ":memory:":
+            _ensure_parent_exists(Path(self._database))
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._database, uri=self._uri)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        for key, value in self._pragmas.items():
+            conn.execute(f"PRAGMA {key}={value};")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        schema = """
+        CREATE TABLE IF NOT EXISTS metadata (
+            run_id TEXT PRIMARY KEY,
+            run_at TEXT NOT NULL,
+            environment TEXT,
+            watchlist TEXT,
+            extra TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS options (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            option_type TEXT,
+            expiration TEXT,
+            strike REAL,
+            contract_symbol TEXT,
+            data TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES metadata(run_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS signals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            option_type TEXT,
+            score REAL,
+            contract_symbol TEXT,
+            data TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES metadata(run_id) ON DELETE CASCADE
+        );
+        """
+        with self._connect() as conn:
+            conn.executescript(schema)
+
+    def save_run(
+        self,
+        metadata: RunMetadata,
+        options: Sequence[OptionSnapshot],
+        signals: Sequence[SignalSnapshot],
+    ) -> None:
+        try:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO metadata(run_id, run_at, environment, watchlist, extra)
+                    VALUES(?, ?, ?, ?, ?)
+                    ON CONFLICT(run_id) DO UPDATE SET
+                        run_at=excluded.run_at,
+                        environment=excluded.environment,
+                        watchlist=excluded.watchlist,
+                        extra=excluded.extra
+                    """,
+                    (
+                        metadata.run_id,
+                        metadata.run_at.isoformat(),
+                        metadata.environment,
+                        metadata.watchlist,
+                        _json_dumps(metadata.extra),
+                    ),
+                )
+                conn.execute("DELETE FROM options WHERE run_id = ?", (metadata.run_id,))
+                conn.execute("DELETE FROM signals WHERE run_id = ?", (metadata.run_id,))
+
+                option_rows = [
+                    (
+                        metadata.run_id,
+                        snapshot.symbol,
+                        snapshot.option_type,
+                        snapshot.expiration,
+                        float(snapshot.strike),
+                        snapshot.contract_symbol,
+                        _json_dumps(snapshot.data),
+                    )
+                    for snapshot in options
+                ]
+                if option_rows:
+                    conn.executemany(
+                        """
+                        INSERT INTO options(run_id, symbol, option_type, expiration, strike, contract_symbol, data)
+                        VALUES(?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        option_rows,
+                    )
+
+                signal_rows = [
+                    (
+                        metadata.run_id,
+                        snapshot.symbol,
+                        snapshot.option_type,
+                        float(snapshot.score),
+                        snapshot.contract_symbol,
+                        _json_dumps(snapshot.data),
+                    )
+                    for snapshot in signals
+                ]
+                if signal_rows:
+                    conn.executemany(
+                        """
+                        INSERT INTO signals(run_id, symbol, option_type, score, contract_symbol, data)
+                        VALUES(?, ?, ?, ?, ?, ?)
+                        """,
+                        signal_rows,
+                    )
+        except sqlite3.DatabaseError as exc:
+            raise StorageError(f"Failed to persist run '{metadata.run_id}': {exc}") from exc
+
+    def list_runs(self, limit: Optional[int] = None) -> List[RunMetadata]:
+        query = "SELECT run_id, run_at, environment, watchlist, extra FROM metadata ORDER BY run_at DESC"
+        if limit is not None:
+            query += " LIMIT ?"
+        with self._connect() as conn:
+            cursor = conn.execute(query, (limit,) if limit is not None else ())
+            rows = cursor.fetchall()
+        return [self._row_to_metadata(row) for row in rows]
+
+    def get_metadata(self, run_id: str) -> Optional[RunMetadata]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "SELECT run_id, run_at, environment, watchlist, extra FROM metadata WHERE run_id = ?",
+                (run_id,),
+            )
+            row = cursor.fetchone()
+        return self._row_to_metadata(row) if row else None
+
+    def get_options(self, run_id: str) -> List[OptionSnapshot]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT symbol, option_type, expiration, strike, contract_symbol, data
+                FROM options
+                WHERE run_id = ?
+                ORDER BY id ASC
+                """,
+                (run_id,),
+            )
+            rows = cursor.fetchall()
+        return [self._row_to_option(row) for row in rows]
+
+    def get_signals(self, run_id: str) -> List[SignalSnapshot]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT symbol, option_type, score, contract_symbol, data
+                FROM signals
+                WHERE run_id = ?
+                ORDER BY id ASC
+                """,
+                (run_id,),
+            )
+            rows = cursor.fetchall()
+        return [self._row_to_signal(row) for row in rows]
+
+    def _row_to_metadata(self, row: sqlite3.Row) -> RunMetadata:
+        extra = _json_loads(row["extra"])
+        return RunMetadata(
+            run_id=row["run_id"],
+            run_at=datetime.fromisoformat(row["run_at"]),
+            environment=row["environment"],
+            watchlist=row["watchlist"],
+            extra=extra,
+        )
+
+    def _row_to_option(self, row: sqlite3.Row) -> OptionSnapshot:
+        return OptionSnapshot(
+            symbol=row["symbol"],
+            option_type=row["option_type"] or "",
+            expiration=row["expiration"] or "",
+            strike=float(row["strike"] or 0.0),
+            contract_symbol=row["contract_symbol"],
+            data=_json_loads(row["data"]),
+        )
+
+    def _row_to_signal(self, row: sqlite3.Row) -> SignalSnapshot:
+        return SignalSnapshot(
+            symbol=row["symbol"],
+            option_type=row["option_type"] or "",
+            score=float(row["score"] or 0.0),
+            contract_symbol=row["contract_symbol"],
+            data=_json_loads(row["data"]),
+        )
+
+
+__all__ = ["SQLiteStorage"]

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -1,0 +1,39 @@
+import pytest
+
+from src.config import get_settings, reset_settings_cache
+from src.config.loader import ENVIRONMENT_VARIABLE
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    reset_settings_cache()
+    yield
+    reset_settings_cache()
+
+
+def test_dev_settings_load(monkeypatch):
+    monkeypatch.setenv(ENVIRONMENT_VARIABLE, "dev")
+    settings = get_settings()
+
+    watchlist = settings.get_watchlist()
+    assert "AAPL" in watchlist
+    assert settings.adapter.provider == "yfinance"
+    assert settings.cache.ttl_seconds == 900
+    assert settings.scoring.weights["risk_reward"] == 1.5
+    assert settings.scoring.score_bounds["max"] == 100.0
+
+
+def test_prod_settings_override(monkeypatch):
+    monkeypatch.setenv(ENVIRONMENT_VARIABLE, "prod")
+    settings = get_settings()
+
+    assert settings.adapter.provider == "polygon"
+    assert "GLD" in settings.get_watchlist("default")
+    assert settings.cache.ttl_seconds == 300
+    assert settings.scoring.score_bounds["min"] == 10.0
+
+
+def test_missing_environment_raises(monkeypatch):
+    monkeypatch.setenv(ENVIRONMENT_VARIABLE, "unknown")
+    with pytest.raises(FileNotFoundError):
+        get_settings()

--- a/tests/storage/test_sqlite.py
+++ b/tests/storage/test_sqlite.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timedelta
+
+from src.storage import OptionSnapshot, RunMetadata, SignalSnapshot
+from src.storage.sqlite import SQLiteStorage
+
+
+def test_save_and_retrieve_run(tmp_path):
+    db_path = tmp_path / "options.db"
+    storage = SQLiteStorage(db_path)
+
+    metadata = RunMetadata(
+        run_id="run-1",
+        run_at=datetime.utcnow(),
+        environment="dev",
+        watchlist="default",
+        extra={"note": "initial"},
+    )
+
+    options = [
+        OptionSnapshot(
+            symbol="AAPL",
+            option_type="call",
+            expiration="2024-12-20",
+            strike=150.0,
+            contract_symbol="AAPL240120C00150000",
+            data={"bid": 1.25, "ask": 1.35},
+        ),
+        OptionSnapshot(
+            symbol="AAPL",
+            option_type="put",
+            expiration="2024-12-20",
+            strike=140.0,
+            contract_symbol="AAPL240120P00140000",
+            data={"bid": 2.1, "ask": 2.3},
+        ),
+    ]
+
+    signals = [
+        SignalSnapshot(
+            symbol="AAPL",
+            option_type="call",
+            score=82.5,
+            contract_symbol="AAPL240120C00150000",
+            data={"total_score": 82.5, "tags": ["gamma"]},
+        )
+    ]
+
+    storage.save_run(metadata, options, signals)
+
+    stored_metadata = storage.get_metadata("run-1")
+    assert stored_metadata is not None
+    assert stored_metadata.environment == "dev"
+    assert stored_metadata.extra["note"] == "initial"
+
+    stored_options = storage.get_options("run-1")
+    assert len(stored_options) == 2
+    assert stored_options[0].symbol == "AAPL"
+
+    stored_signals = storage.get_signals("run-1")
+    assert len(stored_signals) == 1
+    assert stored_signals[0].score == 82.5
+
+    runs = storage.list_runs()
+    assert runs and runs[0].run_id == "run-1"
+
+
+def test_save_run_overwrites_existing(tmp_path):
+    db_path = tmp_path / "options.db"
+    storage = SQLiteStorage(db_path)
+
+    first_metadata = RunMetadata(
+        run_id="duplicate",
+        run_at=datetime.utcnow(),
+        environment="dev",
+        watchlist="default",
+    )
+    second_metadata = RunMetadata(
+        run_id="duplicate",
+        run_at=datetime.utcnow() + timedelta(minutes=5),
+        environment="prod",
+        watchlist="momentum",
+    )
+
+    storage.save_run(
+        first_metadata,
+        [
+            OptionSnapshot(
+                symbol="SPY",
+                option_type="call",
+                expiration="2024-06-21",
+                strike=450.0,
+                contract_symbol="SPY240621C00450000",
+                data={"bid": 3.2},
+            )
+        ],
+        [],
+    )
+
+    storage.save_run(
+        second_metadata,
+        [
+            OptionSnapshot(
+                symbol="SPY",
+                option_type="call",
+                expiration="2024-06-21",
+                strike=455.0,
+                contract_symbol="SPY240621C00455000",
+                data={"bid": 2.8},
+            )
+        ],
+        [
+            SignalSnapshot(
+                symbol="SPY",
+                option_type="call",
+                score=75.0,
+                contract_symbol="SPY240621C00455000",
+                data={"total_score": 75.0},
+            )
+        ],
+    )
+
+    stored_metadata = storage.get_metadata("duplicate")
+    assert stored_metadata is not None
+    assert stored_metadata.environment == "prod"
+    assert stored_metadata.watchlist == "momentum"
+
+    stored_options = storage.get_options("duplicate")
+    assert len(stored_options) == 1
+    assert stored_options[0].strike == 455.0
+
+    stored_signals = storage.get_signals("duplicate")
+    assert len(stored_signals) == 1


### PR DESCRIPTION
## Summary
- introduce dev/prod YAML configs and a typed loader that merges defaults and exposes environment-aware settings
- extract watchlists from the scanner script, load scoring config via the loader, and persist run results through a new SQLite storage layer with migrations stub
- add regression tests covering config parsing and SQLite CRUD behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e34bcec0c0832594a748f5ac5446d8