### PR TITLE
Add catalyst-backed move thesis analysis

### DIFF
--- a/app/api/scan-python/route.ts
+++ b/app/api/scan-python/route.ts
@@ -61,38 +61,127 @@ export async function GET() {
             const rawOpportunities = JSON.parse(jsonString)
             
             // Transform the data to match frontend interface
-            const opportunities = rawOpportunities.map((opp: any) => ({
-              symbol: opp.symbol,
-              optionType: opp.contract?.option_type || 'call',
-              strike: opp.contract?.strike || 0,
-              expiration: opp.contract?.expiration || '',
-              premium: opp.contract?.last_price || 0,
-              bid: opp.contract?.bid || 0,
-              ask: opp.contract?.ask || 0,
-              volume: opp.contract?.volume || 0,
-              openInterest: opp.contract?.open_interest || 0,
-              impliedVolatility: opp.contract?.implied_volatility || 0,
-              stockPrice: opp.contract?.stock_price || 0,
-              score: opp.score?.total_score || 0,
-              confidence: opp.confidence || 0,
-              reasoning: opp.reasons || [],
-              patterns: opp.tags || [],
-              catalysts: ['Technical Analysis', 'Volume Analysis'],
-              riskLevel: opp.tags?.includes('thin-market') ? 'high' : opp.tags?.includes('liquidity') ? 'low' : 'medium',
-              potentialReturn: opp.metadata?.market_data?.projected_returns?.['10%'] ? opp.metadata.market_data.projected_returns['10%'] * 100 : 0,
-              maxReturn: opp.metadata?.market_data?.projected_returns?.['30%'] ? opp.metadata.market_data.projected_returns['30%'] * 100 : 0,
-              maxLoss: opp.contract?.last_price || 0,
-              breakeven: opp.contract?.strike ? (opp.contract.option_type === 'call' ? opp.contract.strike + opp.contract.last_price : opp.contract.strike - opp.contract.last_price) : 0,
-              ivRank: opp.iv_rank || 0,
-              volumeRatio: opp.metadata?.market_data?.volume_ratio || 0,
-              greeks: opp.greeks || { delta: 0, gamma: 0, theta: 0, vega: 0 },
-              daysToExpiration: opp.contract?.expiration ? Math.ceil((new Date(opp.contract.expiration).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)) : 0,
-              returnsAnalysis: [
-                { move: '10%', return: opp.metadata?.market_data?.projected_returns?.['10%'] ? opp.metadata.market_data.projected_returns['10%'] * 100 : 0 },
-                { move: '20%', return: opp.metadata?.market_data?.projected_returns?.['20%'] ? opp.metadata.market_data.projected_returns['20%'] * 100 : 0 },
-                { move: '30%', return: opp.metadata?.market_data?.projected_returns?.['30%'] ? opp.metadata.market_data.projected_returns['30%'] * 100 : 0 }
-              ]
-            }))
+            const opportunities = rawOpportunities.map((opp: any) => {
+              const profitIntel = opp.metadata?.market_data?.profit_probability || opp.score?.metadata?.profit_probability || {}
+              const riskIntel = opp.metadata?.market_data?.risk_metrics || opp.score?.metadata?.risk_metrics || {}
+              const projectedReturns = opp.metadata?.market_data?.projected_returns || {}
+              const moveIntel = opp.metadata?.market_data?.move_rationale || opp.score?.metadata?.move_rationale || null
+              const eventIntel = opp.metadata?.market_data?.event_intel || opp.score?.metadata?.event_intel || null
+              const tenMoveReturn = projectedReturns['10%'] ?? 0
+              const maxReturnPct = projectedReturns['30%'] ?? 0
+              const breakevenMovePct = profitIntel?.required_move_pct
+              const probabilityPercent = typeof profitIntel?.probability === 'number' ? profitIntel.probability * 100 : null
+              const riskRewardRatio = typeof riskIntel?.reward_to_risk === 'number' ? riskIntel.reward_to_risk : null
+              const contractCost = opp.contract?.last_price ? opp.contract.last_price * 100 : 0
+              const maxLossAmount = typeof riskIntel?.max_loss_amount === 'number'
+                ? riskIntel.max_loss_amount
+                : contractCost
+              const pythonMaxLossPct = typeof riskIntel?.max_loss_pct === 'number' ? riskIntel.max_loss_pct : null
+              const normalizedLossPct = contractCost > 0 && maxLossAmount > 0
+                ? (maxLossAmount / contractCost) * 100
+                : null
+              let maxLossPercent = pythonMaxLossPct ?? (normalizedLossPct ?? (contractCost > 0 ? 100 : 0))
+              if (normalizedLossPct !== null && Number.isFinite(normalizedLossPct)) {
+                if (!Number.isFinite(maxLossPercent) || Math.abs(maxLossPercent - normalizedLossPct) > 5) {
+                  maxLossPercent = normalizedLossPct
+                }
+              }
+              const maxReturnPercent = typeof riskIntel?.max_return_pct === 'number'
+                ? riskIntel.max_return_pct
+                : maxReturnPct ? maxReturnPct * 100 : 0
+              const tenPctReturnPercent = typeof riskIntel?.ten_pct_move_return_pct === 'number'
+                ? riskIntel.ten_pct_move_return_pct
+                : tenMoveReturn ? tenMoveReturn * 100 : 0
+              const tenPctReturnAmount = typeof riskIntel?.ten_pct_move_return_amount === 'number'
+                ? riskIntel.ten_pct_move_return_amount
+                : (tenPctReturnPercent / 100) * maxLossAmount
+              const maxReturnAmount = typeof riskIntel?.max_return_amount === 'number'
+                ? riskIntel.max_return_amount
+                : (maxReturnPercent / 100) * maxLossAmount
+
+              const moveAnalysis = moveIntel
+                ? {
+                    expectedMovePercent: typeof moveIntel?.expected_move_pct === 'number' ? moveIntel.expected_move_pct : null,
+                    impliedVol: typeof moveIntel?.implied_vol === 'number' ? moveIntel.implied_vol : null,
+                    daysToExpiration: typeof moveIntel?.days_to_expiration === 'number' ? moveIntel.days_to_expiration : null,
+                    thresholds: Array.isArray(moveIntel?.thresholds)
+                      ? moveIntel.thresholds.map((entry: any) => ({
+                        threshold: typeof entry?.threshold === 'string'
+                          ? entry.threshold
+                          : typeof entry?.threshold === 'number'
+                            ? `${entry.threshold}%`
+                            : '',
+                        baseProbability: typeof entry?.base_probability_pct === 'number' ? entry.base_probability_pct : null,
+                        conviction: typeof entry?.conviction_pct === 'number' ? entry.conviction_pct : null,
+                        summary: typeof entry?.summary === 'string' ? entry.summary : '',
+                        factors: Array.isArray(entry?.factors)
+                          ? entry.factors.map((factor: any) => ({
+                            label: typeof factor?.label === 'string' ? factor.label : '',
+                            detail: typeof factor?.detail === 'string' ? factor.detail : '',
+                            weight: typeof factor?.weight === 'number' ? factor.weight : null,
+                          }))
+                          : [],
+                        historicalSupport: entry?.historical_support
+                          ? {
+                            horizonDays: typeof entry.historical_support?.horizon_days === 'number'
+                              ? entry.historical_support.horizon_days
+                              : null,
+                            probability: typeof entry.historical_support?.probability_pct === 'number'
+                              ? entry.historical_support.probability_pct
+                              : null,
+                          }
+                          : null,
+                      }))
+                      : [],
+                    drivers: Array.isArray(moveIntel?.primary_drivers) ? moveIntel.primary_drivers : [],
+                  }
+                : null
+
+              return {
+                symbol: opp.symbol,
+                optionType: opp.contract?.option_type || 'call',
+                strike: opp.contract?.strike || 0,
+                expiration: opp.contract?.expiration || '',
+                premium: opp.contract?.last_price || 0,
+                bid: opp.contract?.bid || 0,
+                ask: opp.contract?.ask || 0,
+                volume: opp.contract?.volume || 0,
+                openInterest: opp.contract?.open_interest || 0,
+                impliedVolatility: opp.contract?.implied_volatility || 0,
+                stockPrice: opp.contract?.stock_price || 0,
+                score: opp.score?.total_score || 0,
+                confidence: opp.confidence || 0,
+                reasoning: opp.reasons || [],
+                patterns: opp.tags || [],
+                catalysts: ['Technical Analysis', 'Volume Analysis'],
+                riskLevel: opp.tags?.includes('thin-market') ? 'high' : opp.tags?.includes('liquidity') ? 'low' : 'medium',
+                potentialReturn: tenPctReturnPercent,
+                potentialReturnAmount: tenPctReturnAmount,
+                maxReturn: maxReturnPercent,
+                maxReturnAmount,
+                maxLoss: maxLossPercent,
+                maxLossPercent,
+                maxLossAmount,
+                breakeven: opp.contract?.strike ? (opp.contract.option_type === 'call' ? opp.contract.strike + opp.contract.last_price : opp.contract.strike - opp.contract.last_price) : 0,
+                ivRank: opp.iv_rank || 0,
+                volumeRatio: opp.metadata?.market_data?.volume_ratio || 0,
+                greeks: opp.greeks || { delta: 0, gamma: 0, theta: 0, vega: 0 },
+                daysToExpiration: opp.contract?.expiration ? Math.ceil((new Date(opp.contract.expiration).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)) : 0,
+                returnsAnalysis: [
+                  { move: '10%', return: tenPctReturnPercent },
+                  { move: '20%', return: projectedReturns['20%'] ? projectedReturns['20%'] * 100 : 0 },
+                  { move: '30%', return: maxReturnPct ? maxReturnPct * 100 : 0 }
+                ],
+                probabilityOfProfit: probabilityPercent,
+                profitProbabilityExplanation: typeof profitIntel?.explanation === 'string' ? profitIntel.explanation : '',
+                breakevenMovePercent: typeof breakevenMovePct === 'number' ? breakevenMovePct * 100 : null,
+                breakevenPrice: typeof profitIntel?.breakeven_price === 'number' ? profitIntel.breakeven_price : null,
+                riskRewardRatio: riskRewardRatio,
+                shortTermRiskRewardRatio: typeof riskIntel?.ten_pct_move_reward_to_risk === 'number' ? riskIntel.ten_pct_move_reward_to_risk : null,
+                moveAnalysis,
+                eventIntel: eventIntel || null,
+              }
+            })
             
             resolve(
               NextResponse.json({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,29 @@ import ScanProgress from '../components/scan-progress'
 import RealTimeProgress from '../components/real-time-progress'
 import LiveTicker from '../components/live-ticker'
 
+interface MoveAnalysisFactor {
+  label: string
+  detail: string
+  weight: number | null
+}
+
+interface MoveAnalysisThreshold {
+  threshold: string
+  baseProbability: number | null
+  conviction: number | null
+  summary: string
+  factors: MoveAnalysisFactor[]
+  historicalSupport: { horizonDays: number | null; probability: number | null } | null
+}
+
+interface MoveAnalysis {
+  expectedMovePercent: number | null
+  impliedVol: number | null
+  daysToExpiration: number | null
+  thresholds: MoveAnalysisThreshold[]
+  drivers: string[]
+}
+
 interface Opportunity {
   symbol: string
   optionType: string
@@ -19,11 +42,22 @@ interface Opportunity {
   catalysts: string[]
   riskLevel: string
   potentialReturn: number
+  potentialReturnAmount: number
   maxReturn: number
-  maxLoss: number
+  maxReturnAmount: number
+  maxLossPercent: number
+  maxLossAmount: number
   breakeven: number
   ivRank: number
   volumeRatio: number
+  probabilityOfProfit: number | null
+  profitProbabilityExplanation: string
+  breakevenMovePercent: number | null
+  breakevenPrice: number | null
+  riskRewardRatio: number | null
+  shortTermRiskRewardRatio: number | null
+  moveAnalysis: MoveAnalysis | null
+  eventIntel: Record<string, any> | null
   greeks: {
     delta: number
     gamma: number
@@ -72,6 +106,29 @@ interface CryptoAlert {
   reasons: string[]
   urgency: number
   timestamp: string
+}
+
+type InvestmentScenario = {
+  contractCost: number
+  contractsToBuy: number
+  totalCost: number
+  remainingCapital: number
+  requiredCapital: number
+  shortfall: number
+  displayCost: number
+  basis: 'position' | 'perContract'
+  potentialReturnAmount: number
+  potentialReturnAmountPerContract: number
+  maxReturnAmount: number
+  maxReturnAmountPerContract: number
+  maxLossAmount: number
+  maxLossAmountPerContract: number
+  scenarios: Array<{
+    move: string
+    return: number
+    profit: number
+    totalValue: number
+  }>
 }
 
 export default function HomePage() {
@@ -169,12 +226,20 @@ export default function HomePage() {
     }).format(amount)
   }
 
+  const formatPercent = (value: number | null | undefined, digits = 0) => {
+    if (value === null || value === undefined || Number.isNaN(value)) {
+      return '—'
+    }
+    return `${value.toFixed(digits)}%`
+  }
+
   const getTradeLogic = (opp: Opportunity) => {
     const isCall = opp.optionType === 'call'
     const daysToExp = opp.daysToExpiration
     const strikeVsPrice = opp.strike / opp.stockPrice
     const ivRank = opp.ivRank
-    
+    const eventIntel = opp.eventIntel || {}
+
     let logic = ""
     
     // Basic trade direction
@@ -219,7 +284,31 @@ export default function HomePage() {
     if (opp.unusualFlowScore && opp.unusualFlowScore > 0) {
       logic += `Unusual options activity indicates smart money positioning, potentially signaling an upcoming move. `
     }
-    
+
+    if (typeof eventIntel.earnings_in_days === 'number') {
+      if (eventIntel.earnings_in_days >= 0) {
+        logic += `Upcoming earnings in ${Math.round(eventIntel.earnings_in_days)} days could be a key catalyst for volatility. `
+      } else if (eventIntel.earnings_in_days < 0 && eventIntel.earnings_in_days > -7) {
+        logic += `The stock is still reacting to a fresh earnings release from ${Math.abs(Math.round(eventIntel.earnings_in_days))} days ago. `
+      }
+    }
+
+    if (typeof eventIntel.news_sentiment_label === 'string') {
+      const sentimentLabel = String(eventIntel.news_sentiment_label).replace('_', ' ')
+      if (['bullish', 'very bullish', 'bearish', 'very bearish'].includes(sentimentLabel.toLowerCase())) {
+        logic += `News flow is ${sentimentLabel.toLowerCase()}, reinforcing the directional bias behind this trade. `
+      }
+    }
+
+    const drivers = opp.moveAnalysis?.drivers?.length
+      ? opp.moveAnalysis.drivers
+      : Array.isArray(eventIntel.unique_drivers)
+        ? eventIntel.unique_drivers
+        : []
+    if (drivers.length > 0) {
+      logic += `Primary drivers include ${drivers.join(', ')}. `
+    }
+
     return logic
   }
 
@@ -270,27 +359,35 @@ export default function HomePage() {
 
   const getRiskRewardExplanation = (opp: Opportunity) => {
     const maxReturn = opp.maxReturn
-    const maxLoss = opp.maxLoss
+    const maxLossPercent = opp.maxLossPercent
+    const maxLossAmount = opp.maxLossAmount
     const potentialReturn = opp.potentialReturn
     const daysToExp = opp.daysToExpiration
-    
+
     let explanation = `This trade offers a potential return of ${potentialReturn.toFixed(1)}% on a 10% stock move, with a maximum possible return of ${maxReturn.toFixed(1)}%. `
-    
+
     // Risk assessment
-    if (maxLoss < 100) {
-      explanation += `Your maximum loss is limited to ${maxLoss.toFixed(1)}% of your investment. `
+    if (maxLossPercent < 100) {
+      explanation += `Your maximum loss is limited to ${maxLossPercent.toFixed(1)}% of your investment (${formatCurrency(maxLossAmount)} per contract). `
     } else {
-      explanation += `Your maximum loss is ${maxLoss.toFixed(1)}% of your investment. `
+      explanation += `Your maximum loss is ${maxLossPercent.toFixed(1)}% of your investment (${formatCurrency(maxLossAmount)} per contract). `
     }
-    
+
     // Risk/Reward ratio
-    const riskRewardRatio = potentialReturn / Math.abs(maxLoss)
-    if (riskRewardRatio > 5) {
-      explanation += `This creates an excellent risk/reward ratio of ${riskRewardRatio.toFixed(1)}:1, meaning you could make ${riskRewardRatio.toFixed(1)}x more than you could lose. `
-    } else if (riskRewardRatio > 2) {
-      explanation += `This creates a good risk/reward ratio of ${riskRewardRatio.toFixed(1)}:1, providing favorable odds. `
+    const shortTermRatio = opp.shortTermRiskRewardRatio ?? (potentialReturn / Math.max(Math.abs(maxLossPercent), 1))
+    const asymmetryRatio = opp.riskRewardRatio ?? (maxReturn / Math.max(Math.abs(maxLossPercent), 1))
+    if (shortTermRatio > 5) {
+      explanation += `This creates an excellent near-term risk/reward ratio of ${shortTermRatio.toFixed(1)}:1 on a 10% move, meaning you could make ${shortTermRatio.toFixed(1)}x more than you could lose. `
+    } else if (shortTermRatio > 2) {
+      explanation += `This creates a good risk/reward ratio of ${shortTermRatio.toFixed(1)}:1, providing favorable odds even on a modest move. `
     } else {
-      explanation += `This creates a risk/reward ratio of ${riskRewardRatio.toFixed(1)}:1. `
+      explanation += `This creates a risk/reward ratio of ${shortTermRatio.toFixed(1)}:1 on the first 10% move. `
+    }
+
+    if (asymmetryRatio >= 3) {
+      explanation += `The max payoff is ${asymmetryRatio.toFixed(1)}x larger than the capital at risk, giving this setup major asymmetric upside if the stock really runs. `
+    } else if (asymmetryRatio >= 1.5) {
+      explanation += `There's still ${asymmetryRatio.toFixed(1)}x more upside than downside if the bigger move plays out. `
     }
     
     // Time considerations
@@ -305,38 +402,154 @@ export default function HomePage() {
     return explanation
   }
 
-  const calculateInvestmentScenario = (opp: Opportunity, investmentAmount: number) => {
-    const optionPrice = opp.premium
-    const contractCost = optionPrice * 100
-    
-    // Calculate how many contracts we can afford
-    let contractsToBuy = Math.floor(investmentAmount / contractCost)
-    let totalCost = contractsToBuy * contractCost
-    
-    // If we can't afford a full contract, show what we could buy with our full investment
-    if (contractsToBuy === 0 && investmentAmount > 0) {
-      contractsToBuy = 1 // Show 1 contract for demonstration
-      totalCost = investmentAmount // Use full investment amount
+  const renderMoveThesis = (opp: Opportunity) => {
+    const analysis = opp.moveAnalysis
+    if (!analysis || !analysis.thresholds || analysis.thresholds.length === 0) {
+      return null
     }
-    
-    const scenarios = [
-      { move: '5%', return: opp.returnsAnalysis[0]?.return || 0 },
-      { move: '10%', return: opp.returnsAnalysis[0]?.return || 0 },
-      { move: '15%', return: opp.returnsAnalysis[1]?.return || 0 },
-      { move: '20%', return: opp.returnsAnalysis[1]?.return || 0 },
-      { move: '30%', return: opp.returnsAnalysis[2]?.return || 0 }
-    ]
-    
+
+    const horizon = analysis.daysToExpiration ?? opp.daysToExpiration
+
+    return (
+      <div className="bg-sky-50 dark:bg-sky-900/10 border border-sky-100 dark:border-sky-900/40 rounded-2xl p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h5 className="font-medium text-slate-900 dark:text-slate-100">Move Thesis</h5>
+          <div className="text-xs text-sky-700 dark:text-sky-200 font-semibold">
+            {analysis.expectedMovePercent !== null ? `1σ ≈ ${analysis.expectedMovePercent.toFixed(1)}%` : 'IV outlook'}
+          </div>
+        </div>
+        <p className="text-xs text-slate-600 dark:text-slate-300 leading-relaxed">
+          {analysis.impliedVol !== null
+            ? `Implied volatility at ${analysis.impliedVol.toFixed(1)}%`
+            : 'Implied volatility data unavailable'}
+          {horizon ? ` over the next ${horizon} days` : ''} informs expected movement.
+        </p>
+        <div className="space-y-3">
+          {analysis.thresholds.map((threshold, idx) => (
+            <div key={idx} className="bg-white dark:bg-slate-800/60 rounded-xl border border-sky-100 dark:border-slate-700 p-3">
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">{threshold.threshold} target</div>
+                  <div className="text-xs text-slate-500 dark:text-slate-400">
+                    Base {formatPercent(threshold.baseProbability, 0)}
+                  </div>
+                </div>
+                {threshold.conviction !== null && (
+                  <span className="text-xs font-semibold text-sky-600 dark:text-sky-300">
+                    Conviction {formatPercent(threshold.conviction, 0)}
+                  </span>
+                )}
+              </div>
+              {threshold.summary && (
+                <p className="text-xs text-slate-600 dark:text-slate-300 leading-relaxed mb-2">{threshold.summary}</p>
+              )}
+              {threshold.factors.length > 0 && (
+                <ul className="text-xs text-slate-600 dark:text-slate-300 space-y-1">
+                  {threshold.factors.map((factor, factorIndex) => (
+                    <li key={factorIndex}>• {factor.detail}</li>
+                  ))}
+                </ul>
+              )}
+              {threshold.historicalSupport && threshold.historicalSupport.probability !== null && (
+                <div className="text-[10px] text-slate-500 dark:text-slate-400 mt-2">
+                  Historical hit rate: {formatPercent(threshold.historicalSupport.probability, 0)} over {threshold.historicalSupport.horizonDays ?? '—'} days
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+        {analysis.drivers.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {analysis.drivers.map((driver, driverIndex) => (
+              <span
+                key={driverIndex}
+                className="px-2 py-1 bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-200 rounded-full text-xs font-medium"
+              >
+                {driver}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const calculateInvestmentScenario = (opp: Opportunity, amount: number): InvestmentScenario => {
+    const optionPrice = opp.premium || 0
+    const contractCost = Math.max(optionPrice * 100, 0)
+    const perContractPotentialReturn = opp.potentialReturnAmount || ((opp.potentialReturn / 100) * contractCost)
+    const perContractMaxReturn = opp.maxReturnAmount || ((opp.maxReturn / 100) * contractCost)
+    const perContractMaxLoss = opp.maxLossAmount || contractCost
+
+    if (contractCost <= 0) {
+      return {
+        contractCost: 0,
+        contractsToBuy: 0,
+        totalCost: 0,
+        remainingCapital: amount,
+        requiredCapital: 0,
+        shortfall: 0,
+        displayCost: 0,
+        basis: 'perContract',
+        potentialReturnAmount: 0,
+        potentialReturnAmountPerContract: 0,
+        maxReturnAmount: 0,
+        maxReturnAmountPerContract: 0,
+        maxLossAmount: 0,
+        maxLossAmountPerContract: 0,
+        scenarios: [],
+      }
+    }
+
+    const contractsToBuy = Math.max(Math.floor(amount / contractCost), 0)
+    const totalCost = contractsToBuy * contractCost
+    const remainingCapital = Math.max(amount - totalCost, 0)
+    const basis: InvestmentScenario['basis'] = contractsToBuy > 0 ? 'position' : 'perContract'
+    const displayCost = contractsToBuy > 0 ? totalCost : contractCost
+    const requiredCapital = contractCost
+    const shortfall = contractsToBuy > 0 ? 0 : Math.max(requiredCapital - amount, 0)
+
+    const potentialReturnAmount = basis === 'position'
+      ? perContractPotentialReturn * contractsToBuy
+      : perContractPotentialReturn
+
+    const maxReturnAmount = basis === 'position'
+      ? perContractMaxReturn * contractsToBuy
+      : perContractMaxReturn
+
+    const maxLossAmount = basis === 'position'
+      ? perContractMaxLoss * contractsToBuy
+      : perContractMaxLoss
+
+    const scenarioBase = basis === 'position' ? totalCost : contractCost
+
+    const scenarios = (opp.returnsAnalysis || []).map((scenario) => {
+      const percentReturn = scenario?.return || 0
+      const profit = scenarioBase * (percentReturn / 100)
+      return {
+        move: scenario?.move || '',
+        return: percentReturn,
+        profit,
+        totalValue: scenarioBase + profit,
+      }
+    })
+
     return {
+      contractCost,
       contractsToBuy,
       totalCost,
-      remainingCapital: investmentAmount - totalCost,
-      contractCost,
-      scenarios: scenarios.map(scenario => ({
-        ...scenario,
-        profit: (totalCost * scenario.return / 100),
-        totalValue: totalCost + (totalCost * scenario.return / 100)
-      }))
+      remainingCapital,
+      requiredCapital,
+      shortfall,
+      displayCost,
+      basis,
+      potentialReturnAmount,
+      potentialReturnAmountPerContract: perContractPotentialReturn,
+      maxReturnAmount,
+      maxReturnAmountPerContract: perContractMaxReturn,
+      maxLossAmount,
+      maxLossAmountPerContract: perContractMaxLoss,
+      scenarios,
     }
   }
 
@@ -569,8 +782,14 @@ export default function HomePage() {
             </div>
 
             <div className="grid gap-6">
-              {opportunities.map((opp, index) => (
-                <div key={index} className="bg-white dark:bg-slate-900 rounded-3xl p-8 border border-slate-100 dark:border-slate-800 hover:border-slate-200 dark:hover:border-slate-700 transition-colors">
+              {opportunities.map((opp, index) => {
+                const scenario = calculateInvestmentScenario(opp, investmentAmount)
+                const isPerContractView = scenario.basis === 'perContract'
+                const potentialReturnDisplay = isPerContractView ? scenario.potentialReturnAmountPerContract : scenario.potentialReturnAmount
+                const maxReturnDisplay = isPerContractView ? scenario.maxReturnAmountPerContract : scenario.maxReturnAmount
+                const maxLossDisplay = isPerContractView ? scenario.maxLossAmountPerContract : scenario.maxLossAmount
+                return (
+                  <div key={index} className="bg-white dark:bg-slate-900 rounded-3xl p-8 border border-slate-100 dark:border-slate-800 hover:border-slate-200 dark:hover:border-slate-700 transition-colors">
                   <div className="flex items-start justify-between mb-6">
                     <div className="space-y-3">
                       <div className="flex items-center gap-4">
@@ -596,8 +815,18 @@ export default function HomePage() {
                               NEWS: {opp.newsImpactScore}
                             </span>
                           )}
-                </div>
-              </div>
+                          {opp.riskRewardRatio && opp.riskRewardRatio >= 3 && (
+                            <span className="px-3 py-1 bg-emerald-100 text-emerald-700 rounded-xl text-xs font-semibold">
+                              ASYM EDGE {opp.riskRewardRatio.toFixed(1)}x
+                            </span>
+                          )}
+                          {opp.probabilityOfProfit !== null && opp.probabilityOfProfit >= 55 && (
+                            <span className="px-3 py-1 bg-sky-100 text-sky-700 rounded-xl text-xs font-semibold">
+                              WIN RATE {opp.probabilityOfProfit.toFixed(0)}%
+                            </span>
+                          )}
+                        </div>
+                      </div>
                       
                       <div className="flex items-center gap-6 text-sm text-slate-600 dark:text-slate-400">
                         <span>{opp.optionType.toUpperCase()} ${opp.strike}</span>
@@ -688,6 +917,8 @@ export default function HomePage() {
                         </div>
                       </div>
 
+                      {renderMoveThesis(opp)}
+
                       {/* Risk Assessment */}
                       <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-4">
                         <h5 className="font-medium text-slate-900 dark:text-white mb-2">Risk & Reward Profile</h5>
@@ -695,6 +926,35 @@ export default function HomePage() {
                           {getRiskRewardExplanation(opp)}
                         </p>
                       </div>
+                      {opp.probabilityOfProfit !== null && (
+                        <div className="bg-emerald-50 dark:bg-emerald-900/20 rounded-2xl p-4 border border-emerald-200 dark:border-emerald-800">
+                          <div className="flex items-center justify-between mb-3">
+                            <h5 className="font-medium text-emerald-900 dark:text-emerald-100">Likelihood of Profit</h5>
+                            <span className="text-lg font-semibold text-emerald-700 dark:text-emerald-200">
+                              {opp.probabilityOfProfit.toFixed(1)}%
+                            </span>
+                          </div>
+                          <div className="w-full h-2 bg-emerald-100 dark:bg-emerald-900/40 rounded-full overflow-hidden mb-2">
+                            <div
+                              className="h-full bg-emerald-500"
+                              style={{ width: `${Math.max(0, Math.min(opp.probabilityOfProfit, 100)).toFixed(1)}%` }}
+                            ></div>
+                          </div>
+                          <div className="flex items-center justify-between text-xs text-emerald-800 dark:text-emerald-200 mb-3">
+                            {opp.breakevenMovePercent !== null ? (
+                              <span>Needs {opp.breakevenMovePercent.toFixed(1)}% move to breakeven</span>
+                            ) : (
+                              <span>Breakeven move unavailable</span>
+                            )}
+                            {opp.breakevenPrice !== null && (
+                              <span>Breakeven ${opp.breakevenPrice.toFixed(2)}</span>
+                            )}
+                          </div>
+                          <p className="text-sm text-emerald-900 dark:text-emerald-100 leading-relaxed">
+                            {opp.profitProbabilityExplanation || 'Probability estimate unavailable for this contract.'}
+                          </p>
+                        </div>
+                      )}
                     </div>
                   </div>
 
@@ -702,107 +962,152 @@ export default function HomePage() {
                   <div className="mb-6">
                     <h4 className="font-semibold text-slate-900 dark:text-white mb-3">Investment Calculator</h4>
                     <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-6">
-                      {(() => {
-                        const scenario = calculateInvestmentScenario(opp, investmentAmount)
-                        return (
-                          <div className="space-y-4">
-                            {/* Investment Summary */}
-                            <div className="flex items-center justify-between p-4 bg-white dark:bg-slate-700 rounded-xl">
-                              <div>
-                                <div className="text-sm font-medium text-slate-600 dark:text-slate-400">Your Investment</div>
-                                <div className="text-lg font-semibold text-slate-900 dark:text-white">
-                                  {formatCurrency(scenario.totalCost)} for {scenario.contractsToBuy} contract{scenario.contractsToBuy !== 1 ? 's' : ''}
-                                </div>
-                                {scenario.contractsToBuy === 1 && scenario.totalCost < scenario.contractCost && (
-                                  <div className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                                    Partial contract (need {formatCurrency(scenario.contractCost)} for full contract)
-                                  </div>
-                                )}
-                              </div>
-                              <div className="text-right">
-                                <div className="text-sm font-medium text-slate-600 dark:text-slate-400">Option Price</div>
-                                <div className="text-lg font-semibold text-slate-900 dark:text-white">
-                                  {formatCurrency(opp.premium)} per share
-                                </div>
-                                <div className="text-sm text-slate-500 dark:text-slate-400">
-                                  {formatCurrency(scenario.contractCost)} per contract
-                                </div>
-                              </div>
+                      <div className="space-y-4">
+                        {/* Investment Summary */}
+                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 p-4 bg-white dark:bg-slate-700 rounded-xl">
+                          <div>
+                            <div className="text-sm font-medium text-slate-600 dark:text-slate-400">
+                              {scenario.basis === 'position' ? 'Your Position' : 'Per-Contract Preview'}
                             </div>
-
-                            {/* Profit Scenarios */}
-                            <div>
-                              <h5 className="font-medium text-slate-900 dark:text-white mb-3">Potential Profits</h5>
-                              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                                {scenario.scenarios.map((scenarioItem, i) => (
-                                  <div key={i} className="bg-white dark:bg-slate-700 rounded-xl p-4">
-                                    <div className="flex items-center justify-between mb-2">
-                                      <span className="text-sm font-medium text-slate-600 dark:text-slate-400">
-                                        {scenarioItem.move} Stock Move
-                                      </span>
-                                      <span className="text-xs font-semibold text-emerald-600">
-                                        +{scenarioItem.return.toFixed(1)}%
-                                      </span>
-                                    </div>
-                                    <div className="space-y-1">
-                                      <div className="flex justify-between text-sm">
-                                        <span className="text-slate-600 dark:text-slate-400">Profit:</span>
-                                        <span className="font-semibold text-emerald-600">
-                                          {formatCurrency(scenarioItem.profit)}
-                                        </span>
-                                      </div>
-                                      <div className="flex justify-between text-sm">
-                                        <span className="text-slate-600 dark:text-slate-400">Total Value:</span>
-                                        <span className="font-semibold text-slate-900 dark:text-white">
-                                          {formatCurrency(scenarioItem.totalValue)}
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
+                            <div className="text-lg font-semibold text-slate-900 dark:text-white">
+                              {scenario.basis === 'position'
+                                ? `${formatCurrency(scenario.totalCost)} for ${scenario.contractsToBuy} contract${scenario.contractsToBuy !== 1 ? 's' : ''}`
+                                : `${formatCurrency(scenario.displayCost)} per contract`}
                             </div>
-
-                            {/* Risk Warning */}
-                            <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-4">
-                              <div className="flex items-start gap-3">
-                                <div className="w-5 h-5 bg-amber-500 rounded-full flex items-center justify-center mt-0.5">
-                                  <span className="text-xs text-white font-bold">!</span>
-                                </div>
-                                <div>
-                                  <div className="font-medium text-amber-800 dark:text-amber-200 mb-1">Risk Warning</div>
-                                  <div className="text-sm text-amber-700 dark:text-amber-300">
-                                    Maximum loss: {formatCurrency(scenario.totalCost)} (100% of investment). 
-                                    Options can expire worthless, and you could lose your entire investment.
-                  </div>
-                  </div>
-                </div>
+                            {scenario.basis === 'position' ? (
+                              <div className="text-xs text-slate-500 dark:text-slate-300 mt-1">
+                                Remaining capital: {formatCurrency(scenario.remainingCapital)}
+                              </div>
+                            ) : scenario.requiredCapital > 0 ? (
+                              <div className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                                Add {formatCurrency(scenario.shortfall)} more to control one contract (requires {formatCurrency(scenario.requiredCapital)}).
+                              </div>
+                            ) : (
+                              <div className="text-xs text-slate-500 dark:text-slate-300 mt-1">
+                                Waiting for pricing data to size this trade.
+                              </div>
+                            )}
+                          </div>
+                          <div className="text-right">
+                            <div className="text-sm font-medium text-slate-600 dark:text-slate-400">Option Price</div>
+                            <div className="text-lg font-semibold text-slate-900 dark:text-white">
+                              {formatCurrency(opp.premium)} per share
+                            </div>
+                            <div className="text-sm text-slate-500 dark:text-slate-400">
+                              {formatCurrency(scenario.contractCost)} per contract
                             </div>
                           </div>
-                        )
-                      })()}
+                        </div>
+
+                        {/* Profit Scenarios */}
+                        <div>
+                          <div className="flex items-center justify-between mb-3">
+                            <h5 className="font-medium text-slate-900 dark:text-white">Potential Profits</h5>
+                            {isPerContractView && (
+                              <span className="text-xs font-medium text-amber-600 dark:text-amber-300">
+                                Showing per-contract economics
+                              </span>
+                            )}
+                          </div>
+                          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                            {scenario.scenarios.map((scenarioItem, i) => (
+                              <div key={i} className="bg-white dark:bg-slate-700 rounded-xl p-4">
+                                <div className="flex items-center justify-between mb-2">
+                                  <span className="text-sm font-medium text-slate-600 dark:text-slate-400">
+                                    {scenarioItem.move || `${scenarioItem.return.toFixed(0)}%`} Stock Move
+                                  </span>
+                                  <span className="text-xs font-semibold text-emerald-600">
+                                    +{scenarioItem.return.toFixed(1)}%
+                                  </span>
+                                </div>
+                                <div className="space-y-1">
+                                  <div className="flex justify-between text-sm">
+                                    <span className="text-slate-600 dark:text-slate-400">Profit:</span>
+                                    <span className="font-semibold text-emerald-600">
+                                      {formatCurrency(scenarioItem.profit)}
+                                    </span>
+                                  </div>
+                                  <div className="flex justify-between text-sm">
+                                    <span className="text-slate-600 dark:text-slate-400">Total Value:</span>
+                                    <span className="font-semibold text-slate-900 dark:text-white">
+                                      {formatCurrency(scenarioItem.totalValue)}
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+
+                        {/* Risk Warning */}
+                        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-4">
+                          <div className="flex items-start gap-3">
+                            <div className="w-5 h-5 bg-amber-500 rounded-full flex items-center justify-center mt-0.5">
+                              <span className="text-xs text-white font-bold">!</span>
+                            </div>
+                            <div>
+                              <div className="font-medium text-amber-800 dark:text-amber-200 mb-1">Risk Warning</div>
+                              <div className="text-sm text-amber-700 dark:text-amber-300">
+                                Maximum loss: {formatCurrency(maxLossDisplay)} ({opp.maxLossPercent.toFixed(1)}% {isPerContractView ? 'per contract' : 'of deployed capital'}).
+                                Options can expire worthless, and you could lose your entire investment.
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
 
                   {/* Key Metrics */}
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+                  <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
                     <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-4">
                       <div className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Potential Return</div>
                       <div className="text-lg font-semibold text-emerald-600">{opp.potentialReturn.toFixed(1)}%</div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        ≈ {formatCurrency(potentialReturnDisplay)} {isPerContractView ? 'per contract' : ''}
+                      </div>
                     </div>
                     <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-4">
                       <div className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Max Return</div>
                       <div className="text-lg font-semibold text-emerald-600">{opp.maxReturn.toFixed(1)}%</div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        ≈ {formatCurrency(maxReturnDisplay)} {isPerContractView ? 'per contract' : ''}
+                      </div>
                     </div>
                     <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-4">
                       <div className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Max Loss</div>
-                      <div className="text-lg font-semibold text-red-600">{opp.maxLoss.toFixed(1)}%</div>
+                      <div className="text-lg font-semibold text-red-600">{opp.maxLossPercent.toFixed(1)}%</div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        ≈ {formatCurrency(maxLossDisplay)} {isPerContractView ? 'per contract' : ''}
+                      </div>
+                      {opp.riskRewardRatio && opp.riskRewardRatio >= 3 && (
+                        <div className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-emerald-600">
+                          <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                          {opp.riskRewardRatio.toFixed(1)}x upside vs risk
+                        </div>
+                      )}
                     </div>
                     <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-4">
-                      <div className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Breakeven</div>
-                      <div className="text-lg font-semibold text-slate-900 dark:text-white">${opp.breakeven.toFixed(2)}</div>
-              </div>
-            </div>
+                      <div className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Profit Probability</div>
+                      <div className="text-lg font-semibold text-slate-900 dark:text-white">
+                        {opp.probabilityOfProfit !== null ? `${opp.probabilityOfProfit.toFixed(1)}%` : '—'}
+                      </div>
+                      {opp.breakevenMovePercent !== null && (
+                        <div className="text-xs text-slate-500 dark:text-slate-400">
+                          Needs {opp.breakevenMovePercent.toFixed(1)}% move
+                        </div>
+                      )}
+                    </div>
+                    <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-4">
+                      <div className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Reward-to-Risk</div>
+                      <div className={`text-lg font-semibold ${opp.riskRewardRatio && opp.riskRewardRatio >= 3 ? 'text-emerald-600' : 'text-slate-900 dark:text-white'}`}>
+                        {opp.riskRewardRatio ? `${opp.riskRewardRatio.toFixed(1)}x` : '—'}
+                      </div>
+                      {opp.riskRewardRatio && opp.riskRewardRatio >= 3 && (
+                        <div className="text-xs text-emerald-600">Asymmetric payoff</div>
+                      )}
+                    </div>
+                  </div>
 
                   {/* Greeks */}
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
@@ -824,7 +1129,7 @@ export default function HomePage() {
                 </div>
                 </div>
                 </div>
-              ))}
+              )})}
             </div>
           </div>
         )}

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -8,23 +8,41 @@ watchlists:
     - QQQ
     - IWM
     - AMD
+    - COIN
+    - HOOD
   growth:
     - SHOP
     - SNOW
     - PLTR
     - CRWD
     - MDB
+  high_volatility:
+    - HOOD
+    - COIN
+    - PLTR
+    - SMCI
+    - AI
+    - MARA
+  ai_infrastructure:
+    - NVDA
+    - SMCI
+    - AVGO
+    - ASML
+    - PLTR
+    - ANET
 scoring:
   enabled:
     - volume
     - iv_rank
     - liquidity
     - risk_reward
+    - event_catalyst
   weights:
     volume: 1.0
     iv_rank: 1.2
     liquidity: 0.8
     risk_reward: 1.5
+    event_catalyst: 1.0
   score_bounds:
     min: 0.0
     max: 100.0

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -5,23 +5,39 @@ watchlists:
     - DIA
     - IWM
     - GLD
+    - COIN
+    - HOOD
   momentum:
     - NVDA
     - TSLA
     - META
     - AMD
     - GOOGL
+  high_volatility:
+    - HOOD
+    - COIN
+    - PLTR
+    - SMCI
+    - MARA
+  ai_infrastructure:
+    - NVDA
+    - AVGO
+    - SMCI
+    - ASML
+    - PLTR
 scoring:
   enabled:
     - volume
     - iv_rank
     - liquidity
     - risk_reward
+    - event_catalyst
   weights:
     volume: 1.1
     iv_rank: 1.3
     liquidity: 0.9
     risk_reward: 1.7
+    event_catalyst: 1.1
   score_bounds:
     min: 10.0
     max: 100.0

--- a/src/scoring/__init__.py
+++ b/src/scoring/__init__.py
@@ -1,6 +1,7 @@
 """Convenient exports for scoring components."""
 
 from .engine import CompositeScoringEngine
+from .event_catalyst import EventCatalystScorer
 from .gamma_squeeze import GammaSqueezeScorer
 from .iv_anomaly import IVAnomalyScorer
 from .iv_rank import IVRankScorer
@@ -10,6 +11,7 @@ from .volume import VolumeScorer
 
 __all__ = [
     "CompositeScoringEngine",
+    "EventCatalystScorer",
     "GammaSqueezeScorer",
     "IVAnomalyScorer",
     "IVRankScorer",

--- a/src/scoring/engine.py
+++ b/src/scoring/engine.py
@@ -6,6 +6,7 @@ from src.models.option import OptionContract, OptionGreeks, OptionScore, Scoring
 
 from .base import ScoreContext
 from .config import merge_config
+from .event_catalyst import EventCatalystScorer
 from .gamma_squeeze import GammaSqueezeScorer
 from .iv_anomaly import IVAnomalyScorer
 from .iv_rank import IVRankScorer
@@ -20,6 +21,7 @@ SCORER_REGISTRY = {
     IVRankScorer.key: IVRankScorer,
     LiquidityScorer.key: LiquidityScorer,
     RiskRewardScorer.key: RiskRewardScorer,
+    EventCatalystScorer.key: EventCatalystScorer,
 }
 
 

--- a/src/scoring/event_catalyst.py
+++ b/src/scoring/event_catalyst.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+from .base import ScoreContext
+
+
+class EventCatalystScorer:
+    """Scores contracts based on upcoming catalysts and thematic drivers."""
+
+    key = "event_catalyst"
+    default_weight = 1.1
+
+    _BULLISH_SENTIMENT_THRESHOLD = 0.3
+    _BEARISH_SENTIMENT_THRESHOLD = -0.3
+
+    def score(self, context: ScoreContext) -> Tuple[float, List[str], List[str]]:
+        data = context.market_data.get("event_intel", {})
+        reasons: List[str] = []
+        tags: List[str] = ["catalyst"]
+        score = 0.0
+
+        earnings_in_days = self._get_number(data, "earnings_in_days")
+        if earnings_in_days is not None:
+            if 0 <= earnings_in_days <= 7:
+                score += 18
+                reasons.append(f"Earnings within {int(earnings_in_days)} days")
+                tags.extend(["earnings-play", "volatility-catalyst"])
+            elif 7 < earnings_in_days <= 14:
+                score += 10
+                reasons.append("Earnings approaching in two weeks")
+            elif earnings_in_days < 0:
+                days_since = abs(int(earnings_in_days))
+                if days_since <= 3:
+                    score += 12
+                    reasons.append("Fresh post-earnings momentum window")
+                    tags.append("post-earnings")
+                elif days_since <= 7:
+                    score += 6
+                    reasons.append("Recent earnings move still in play")
+
+        sentiment_score = self._get_number(data, "news_sentiment_score")
+        sentiment_label = data.get("news_sentiment_label")
+        if sentiment_score is not None:
+            if sentiment_score >= self._BULLISH_SENTIMENT_THRESHOLD:
+                score += 12
+                reasons.append(
+                    f"Positive news flow ({sentiment_label or 'bullish'}) driving interest"
+                )
+                tags.append("news-tailwind")
+            elif sentiment_score <= self._BEARISH_SENTIMENT_THRESHOLD:
+                score -= 15
+                reasons.append(
+                    f"Headline risk detected ({sentiment_label or 'bearish'} sentiment)"
+                )
+                tags.append("headline-risk")
+            else:
+                score += 4
+                reasons.append("Neutral-to-positive headline tone")
+
+        political_hits: Sequence[str] = data.get("political_hits", [])
+        if political_hits:
+            score += 8
+            reasons.append(f"Policy catalyst in play: {', '.join(political_hits[:2])}")
+            tags.append("policy-catalyst")
+
+        ai_hits: Sequence[str] = data.get("ai_infra_hits", [])
+        if ai_hits:
+            score += 9
+            reasons.append("AI/infra demand narrative supporting flows")
+            tags.append("ai-infrastructure")
+
+        volatility_label = data.get("volatility_label")
+        if volatility_label in {"extreme", "elevated"}:
+            score += 6
+            reasons.append("Underlying exhibits outsized realized volatility")
+            tags.append("high-volatility")
+
+        focus_flags: Sequence[str] = data.get("unique_drivers", [])
+        if focus_flags:
+            score += 5
+            reasons.append(f"Unique opportunity drivers: {', '.join(focus_flags[:3])}")
+            tags.append("unique-opportunity")
+
+        if not reasons:
+            score -= 5
+            reasons.append("No identifiable catalyst edge")
+            tags.append("no-catalyst")
+
+        return score, reasons, sorted(set(tags))
+
+    @staticmethod
+    def _get_number(data: dict, key: str) -> float | None:
+        value = data.get(key)
+        try:
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+
+__all__ = ["EventCatalystScorer"]

--- a/tests/scoring/test_engine.py
+++ b/tests/scoring/test_engine.py
@@ -42,6 +42,15 @@ def build_market_data() -> dict:
             "iv_rv_spread": 27.0,
         },
         "projected_returns": {"10%": 6.2, "20%": 9.1, "30%": 12.4},
+        "event_intel": {
+            "earnings_in_days": 5,
+            "news_sentiment_score": 0.42,
+            "news_sentiment_label": "bullish",
+            "political_hits": ["congress"],
+            "ai_infra_hits": ["data center"],
+            "volatility_label": "elevated",
+            "unique_drivers": ["AI infrastructure demand", "positive news momentum"],
+        },
     }
 
 

--- a/tests/scoring/test_event_catalyst.py
+++ b/tests/scoring/test_event_catalyst.py
@@ -1,0 +1,71 @@
+from datetime import date, timedelta
+
+from src.models.option import OptionContract, OptionGreeks
+from src.scoring.base import ScoreContext
+from src.scoring.event_catalyst import EventCatalystScorer
+
+
+def _sample_contract() -> OptionContract:
+    expiration = (date.today() + timedelta(days=35)).isoformat()
+    return OptionContract.parse_obj(
+        {
+            "symbol": "COIN",
+            "type": "call",
+            "strike": 150.0,
+            "expiration": expiration,
+            "lastPrice": 3.1,
+            "bid": 3.0,
+            "ask": 3.2,
+            "volume": 4200,
+            "openInterest": 5000,
+            "impliedVolatility": 0.65,
+            "stockPrice": 148.0,
+        }
+    )
+
+
+def _build_context(event_data: dict) -> ScoreContext:
+    return ScoreContext(
+        contract=_sample_contract(),
+        greeks=OptionGreeks(),
+        market_data={"event_intel": event_data},
+        config={"weights": {}},
+    )
+
+
+def test_event_catalyst_rewards_upcoming_earnings():
+    scorer = EventCatalystScorer()
+    context = _build_context(
+        {
+            "earnings_in_days": 3,
+            "news_sentiment_score": 0.36,
+            "news_sentiment_label": "bullish",
+            "political_hits": ["policy"],
+            "ai_infra_hits": ["data center"],
+            "volatility_label": "elevated",
+            "unique_drivers": ["AI infrastructure demand"],
+        }
+    )
+
+    score, reasons, tags = scorer.score(context)
+
+    assert score > 0
+    assert any("Earnings within" in reason for reason in reasons)
+    assert "catalyst" in tags
+    assert "ai-infrastructure" in tags
+
+
+def test_event_catalyst_penalizes_negative_headlines():
+    scorer = EventCatalystScorer()
+    context = _build_context(
+        {
+            "news_sentiment_score": -0.5,
+            "news_sentiment_label": "bearish",
+        }
+    )
+
+    score, reasons, tags = scorer.score(context)
+
+    assert score < 0
+    assert any("Headline risk" in reason for reason in reasons)
+    assert "headline-risk" in tags

--- a/tests/scripts/test_fetch_options_data.py
+++ b/tests/scripts/test_fetch_options_data.py
@@ -1,0 +1,104 @@
+from datetime import date, timedelta
+
+import pandas as pd
+
+from scripts.fetch_options_data import (
+    calculate_greeks,
+    build_move_thesis,
+    estimate_profit_probability,
+    summarize_risk_metrics,
+)
+from src.models.option import OptionContract
+
+
+def make_future_expiration(days: int = 120) -> str:
+    return (date.today() + timedelta(days=days)).isoformat()
+
+
+def test_calculate_greeks_falls_back_when_iv_missing():
+    row = pd.Series(
+        {
+            "stockPrice": 150.0,
+            "strike": 145.0,
+            "expiration": make_future_expiration(150),
+            "impliedVolatility": 0.0,
+            "type": "call",
+        }
+    )
+
+    greeks = calculate_greeks(row)
+
+    assert greeks.delta != 0.0
+    assert greeks.gamma != 0.0
+
+
+def build_sample_contract() -> OptionContract:
+    return OptionContract.parse_obj(
+        {
+            "symbol": "NVDA",
+            "type": "call",
+            "strike": 450.0,
+            "expiration": make_future_expiration(90),
+            "lastPrice": 12.5,
+            "bid": 12.0,
+            "ask": 13.0,
+            "volume": 5000,
+            "openInterest": 4200,
+            "impliedVolatility": 0.55,
+            "stockPrice": 470.0,
+        }
+    )
+
+
+def test_estimate_profit_probability_returns_reasonable_values():
+    contract = build_sample_contract()
+
+    intel = estimate_profit_probability(contract)
+
+    assert 0.0 <= intel["probability"] <= 1.0
+    explanation = intel["explanation"].lower()
+    assert "break even" in explanation or "breakeven" in explanation
+    assert intel["required_move_pct"] is None or intel["required_move_pct"] >= 0.0
+
+
+def test_summarize_risk_metrics_produces_asymmetry_ratio():
+    contract = build_sample_contract()
+    projected_returns = {"10%": 2.4, "20%": 3.6, "30%": 5.2}
+
+    metrics = summarize_risk_metrics(contract, projected_returns)
+
+    assert metrics["max_return_pct"] == 520.0
+    assert metrics["max_loss_pct"] == 100.0
+    assert metrics["reward_to_risk"] > 1.0
+    assert metrics["max_loss_amount"] == round(contract.last_price * 100, 2)
+    assert metrics["max_return_amount"] == round(metrics["max_return_pct"] / 100 * contract.last_price * 100, 2)
+    assert metrics["premium_per_contract"] == round(contract.last_price * 100, 2)
+    assert metrics["max_loss_pct"] == round(metrics["max_loss_amount"] / metrics["premium_per_contract"] * 100, 2)
+
+
+def test_build_move_thesis_blends_catalyst_inputs():
+    contract = build_sample_contract()
+    event_context = {
+        "earnings_in_days": 4,
+        "news_sentiment_label": "bullish",
+        "news_sentiment_score": 0.42,
+        "volatility_label": "elevated",
+        "historical_moves": {
+            "5": {"prob_5pct": 0.45, "prob_10pct": 0.18, "samples": 120},
+        },
+        "unique_drivers": ["positive news momentum"],
+    }
+    gamma_signal = {"risk_level": "HIGH", "score": 35}
+    iv_anomaly = {"zscore": 1.8}
+
+    thesis = build_move_thesis(contract, event_context, gamma_signal, iv_anomaly)
+
+    assert thesis["expected_move_pct"] > 0
+    assert thesis["implied_vol"] > 0
+    thresholds = thesis["thresholds"]
+    assert any(entry["threshold"] == "5%" for entry in thresholds)
+    five_threshold = next(entry for entry in thresholds if entry["threshold"] == "5%")
+    assert five_threshold["conviction_pct"] >= five_threshold["base_probability_pct"]
+    catalyst_details = " ".join(factor["detail"] for factor in five_threshold["factors"])
+    assert "earnings" in catalyst_details.lower()
+    assert "volatility" in catalyst_details.lower() or "gamma" in catalyst_details.lower()


### PR DESCRIPTION
## Summary
- extend the Python scan to capture historical move context and build a catalyst-weighted move thesis for each contract
- surface the move thesis via the scan API and dashboard so traders can see the probability context, supporting factors, and key drivers
- add a regression test locking the multi-factor move thesis behaviour

## Testing
- pytest tests/scripts/test_fetch_options_data.py -q
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fefcfc80832597849ecbe99793be