### PR TITLE
Fix build failures and enrich opportunity details

### DIFF
--- a/app/api/crypto-scan/route.ts
+++ b/app/api/crypto-scan/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
       errorOutput += data.toString()
     })
 
-    return new Promise((resolve) => {
+    return await new Promise<NextResponse>((resolve) => {
       pythonProcess.on('close', (code) => {
         if (code === 0) {
           try {

--- a/app/api/news-python/route.ts
+++ b/app/api/news-python/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
   try {
     const { spawn } = await import("child_process")
 
-    return new Promise((resolve) => {
+    return await new Promise<NextResponse>((resolve) => {
       const python = spawn("./venv/bin/python3", ["scripts/fetch_market_news.py"])
 
       let dataString = ""

--- a/app/api/quotes-python/route.ts
+++ b/app/api/quotes-python/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: Request) {
 
     const { spawn } = await import("child_process")
 
-    return new Promise((resolve) => {
+    return await new Promise<NextResponse>((resolve) => {
       const python = spawn("./venv/bin/python3", ["scripts/get_stock_quotes.py", symbols])
 
       let dataString = ""

--- a/app/api/scan-python/route.ts
+++ b/app/api/scan-python/route.ts
@@ -65,7 +65,7 @@ export async function GET() {
     // Execute Python script to scan for opportunities
     const { spawn } = await import("child_process")
 
-    return new Promise((resolve) => {
+    return await new Promise<NextResponse>((resolve) => {
       const python = spawn("./venv/bin/python3", ["scripts/fetch_options_data.py"], {
         env: { ...process.env, PYTHONPATH: process.cwd() }
       })
@@ -111,86 +111,91 @@ export async function GET() {
               break
             }
           }
-          
-            if (jsonString) {
-              console.log("JSON string length:", jsonString.length)
-              console.log("JSON starts with:", jsonString.slice(0, 100))
-              const parsed = JSON.parse(jsonString)
-              const rawOpportunities: RawOpportunity[] = Array.isArray(parsed) ? parsed : []
 
-              // Transform the data to match frontend interface
-              const opportunities = rawOpportunities.map((opp) => {
-                const profitIntel =
-                  opp.metadata?.market_data?.profit_probability ??
-                  opp.score?.metadata?.profit_probability
-                const riskIntel =
-                  opp.metadata?.market_data?.risk_metrics ?? opp.score?.metadata?.risk_metrics
-                const projectedReturns = opp.metadata?.market_data?.projected_returns ?? {}
-                const tenMoveReturn = projectedReturns['10%'] ?? 0
-                const maxReturnPct = projectedReturns['30%'] ?? 0
-                const breakevenMovePct = profitIntel?.required_move_pct
-                const probabilityPercent =
-                  typeof profitIntel?.probability === 'number' ? profitIntel.probability * 100 : null
-                const riskRewardRatio =
-                  typeof riskIntel?.reward_to_risk === 'number' ? riskIntel.reward_to_risk : null
+          if (jsonString) {
+            console.log("JSON string length:", jsonString.length)
+            console.log("JSON starts with:", jsonString.slice(0, 100))
+            const parsed = JSON.parse(jsonString)
+            const rawOpportunities: RawOpportunity[] = Array.isArray(parsed) ? parsed : []
 
-                return {
-                  symbol: opp.symbol,
-                  optionType: opp.contract?.option_type || 'call',
-                  strike: opp.contract?.strike || 0,
-                  expiration: opp.contract?.expiration || '',
-                  premium: opp.contract?.last_price || 0,
-                  bid: opp.contract?.bid || 0,
-                  ask: opp.contract?.ask || 0,
-                  volume: opp.contract?.volume || 0,
-                  openInterest: opp.contract?.open_interest || 0,
-                  impliedVolatility: opp.contract?.implied_volatility || 0,
-                  stockPrice: opp.contract?.stock_price || 0,
-                  score: opp.score?.total_score || 0,
-                  confidence: opp.confidence || 0,
-                  reasoning: opp.reasons || [],
-                  patterns: opp.tags || [],
-                  catalysts: ['Technical Analysis', 'Volume Analysis'],
-                  riskLevel: opp.tags?.includes('thin-market')
-                    ? 'high'
-                    : opp.tags?.includes('liquidity')
-                      ? 'low'
-                      : 'medium',
-                  potentialReturn: tenMoveReturn ? tenMoveReturn * 100 : 0,
-                  maxReturn: maxReturnPct ? maxReturnPct * 100 : 0,
-                  maxLoss: typeof riskIntel?.max_loss_pct === 'number' ? riskIntel.max_loss_pct : 100,
-                  breakeven: opp.contract?.strike
-                    ? opp.contract.option_type === 'call'
-                      ? opp.contract.strike + opp.contract.last_price
-                      : opp.contract.strike - opp.contract.last_price
-                    : 0,
-                  ivRank: opp.iv_rank || 0,
-                  volumeRatio: opp.metadata?.market_data?.volume_ratio || 0,
-                  greeks: opp.greeks || { delta: 0, gamma: 0, theta: 0, vega: 0 },
-                  daysToExpiration: opp.contract?.expiration
-                    ? Math.ceil(
-                        (new Date(opp.contract.expiration).getTime() - new Date().getTime()) /
-                          (1000 * 60 * 60 * 24),
-                      )
-                    : 0,
-                  returnsAnalysis: [
-                    { move: '10%', return: tenMoveReturn ? tenMoveReturn * 100 : 0 },
-                    { move: '20%', return: projectedReturns['20%'] ? projectedReturns['20%'] * 100 : 0 },
-                    { move: '30%', return: maxReturnPct ? maxReturnPct * 100 : 0 }
-                  ],
-                  probabilityOfProfit: probabilityPercent,
-                  profitProbabilityExplanation:
-                    typeof profitIntel?.explanation === 'string' ? profitIntel.explanation : '',
-                  breakevenMovePercent: typeof breakevenMovePct === 'number' ? breakevenMovePct * 100 : null,
-                  breakevenPrice: typeof profitIntel?.breakeven_price === 'number' ? profitIntel.breakeven_price : null,
-                  riskRewardRatio,
-                  shortTermRiskRewardRatio:
-                    typeof riskIntel?.ten_pct_move_reward_to_risk === 'number'
-                      ? riskIntel.ten_pct_move_reward_to_risk
-                      : null,
-                }
-              })
-            
+            // Transform the data to match frontend interface
+            const opportunities = rawOpportunities.map((opp) => {
+              const profitIntel =
+                opp.metadata?.market_data?.profit_probability ??
+                opp.score?.metadata?.profit_probability
+              const riskIntel =
+                opp.metadata?.market_data?.risk_metrics ?? opp.score?.metadata?.risk_metrics
+              const projectedReturns = opp.metadata?.market_data?.projected_returns ?? {}
+              const tenMoveReturn = projectedReturns['10%'] ?? 0
+              const maxReturnPct = projectedReturns['30%'] ?? 0
+              const breakevenMovePct = profitIntel?.required_move_pct
+              const probabilityPercent =
+                typeof profitIntel?.probability === 'number' ? profitIntel.probability * 100 : null
+              const riskRewardRatio =
+                typeof riskIntel?.reward_to_risk === 'number' ? riskIntel.reward_to_risk : null
+              const optionType = opp.contract?.option_type || 'call'
+              const strike = opp.contract?.strike ?? 0
+              const lastPrice = opp.contract?.last_price ?? 0
+              const breakeven =
+                strike && lastPrice
+                  ? optionType === 'call'
+                    ? strike + lastPrice
+                    : strike - lastPrice
+                  : 0
+
+              return {
+                symbol: opp.symbol,
+                optionType,
+                strike,
+                expiration: opp.contract?.expiration || '',
+                premium: lastPrice,
+                bid: opp.contract?.bid || 0,
+                ask: opp.contract?.ask || 0,
+                volume: opp.contract?.volume || 0,
+                openInterest: opp.contract?.open_interest || 0,
+                impliedVolatility: opp.contract?.implied_volatility || 0,
+                stockPrice: opp.contract?.stock_price || 0,
+                score: opp.score?.total_score || 0,
+                confidence: opp.confidence || 0,
+                reasoning: opp.reasons || [],
+                patterns: opp.tags || [],
+                catalysts: ['Technical Analysis', 'Volume Analysis'],
+                riskLevel: opp.tags?.includes('thin-market')
+                  ? 'high'
+                  : opp.tags?.includes('liquidity')
+                    ? 'low'
+                    : 'medium',
+                potentialReturn: tenMoveReturn ? tenMoveReturn * 100 : 0,
+                maxReturn: maxReturnPct ? maxReturnPct * 100 : 0,
+                maxLoss: typeof riskIntel?.max_loss_pct === 'number' ? riskIntel.max_loss_pct : 100,
+                breakeven,
+                ivRank: opp.iv_rank || 0,
+                volumeRatio: opp.metadata?.market_data?.volume_ratio || 0,
+                greeks: opp.greeks || { delta: 0, gamma: 0, theta: 0, vega: 0 },
+                daysToExpiration: opp.contract?.expiration
+                  ? Math.ceil(
+                      (new Date(opp.contract.expiration).getTime() - new Date().getTime()) /
+                        (1000 * 60 * 60 * 24),
+                    )
+                  : 0,
+                returnsAnalysis: [
+                  { move: '10%', return: tenMoveReturn ? tenMoveReturn * 100 : 0 },
+                  { move: '20%', return: projectedReturns['20%'] ? projectedReturns['20%'] * 100 : 0 },
+                  { move: '30%', return: maxReturnPct ? maxReturnPct * 100 : 0 }
+                ],
+                probabilityOfProfit: probabilityPercent,
+                profitProbabilityExplanation:
+                  typeof profitIntel?.explanation === 'string' ? profitIntel.explanation : '',
+                breakevenMovePercent: typeof breakevenMovePct === 'number' ? breakevenMovePct * 100 : null,
+                breakevenPrice: typeof profitIntel?.breakeven_price === 'number' ? profitIntel.breakeven_price : null,
+                riskRewardRatio,
+                shortTermRiskRewardRatio:
+                  typeof riskIntel?.ten_pct_move_reward_to_risk === 'number'
+                    ? riskIntel.ten_pct_move_reward_to_risk
+                    : null,
+              }
+            })
+
             resolve(
               NextResponse.json({
                 success: true,
@@ -213,7 +218,16 @@ export async function GET() {
         } catch (error) {
           console.error("Error parsing Python output:", error)
           console.error("Raw data:", dataString)
-          resolve(NextResponse.json({ success: false, error: "Failed to parse scan results", details: error.message }, { status: 500 }))
+          resolve(
+            NextResponse.json(
+              {
+                success: false,
+                error: "Failed to parse scan results",
+                details: error instanceof Error ? error.message : String(error),
+              },
+              { status: 500 },
+            ),
+          )
         }
       })
     })

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
-import { Roboto_Mono } from "next/font/google"
 import "./globals.css"
 import { Suspense } from "react"
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-  display: "swap",
-})
-
-const robotoMono = Roboto_Mono({
-  subsets: ["latin"],
-  variable: "--font-roboto-mono",
-  display: "swap",
-})
 
 export const metadata: Metadata = {
   title: "Options Trading Dashboard",
@@ -30,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
-      <body className={`font-sans ${inter.variable} ${robotoMono.variable} antialiased`}>
+      <body className="font-sans antialiased">
         <Suspense fallback={null}>{children}</Suspense>
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@types/react-dom": "^18",
         "@types/supertest": "^6.0.3",
         "autoprefixer": "^10.4.20",
-        "eslint": "^9.14.0",
+        "eslint": "^9.37.0",
         "eslint-config-next": "15.5.4",
         "postcss": "^8.5",
         "supertest": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-tooltip": "1.1.6",
     "@vercel/analytics": "1.3.1",
     "autoprefixer": "^10.4.20",
+    "child_process": "1.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
@@ -57,24 +58,23 @@
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.4",
     "sonner": "^1.7.4",
+    "swr": "2.3.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "3.25.67",
-    "swr": "2.3.6",
-    "child_process": "1.0.2"
+    "zod": "3.25.67"
   },
   "devDependencies": {
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/supertest": "^6.0.3",
     "autoprefixer": "^10.4.20",
-    "eslint": "^9.14.0",
+    "eslint": "^9.37.0",
     "eslint-config-next": "15.5.4",
     "postcss": "^8.5",
+    "supertest": "^7.0.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5",
-    "@types/supertest": "^6.0.3",
-    "supertest": "^7.0.0",
     "vitest": "^2.1.5"
   }
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach } from "vitest"
+import { afterEach, beforeEach, vi } from "vitest"
 
 beforeEach(() => {
   vi.restoreAllMocks()


### PR DESCRIPTION
## Summary
- stop pulling Google Fonts at build time and rely on local font classes
- harden Python-backed API routes with typed `NextResponse` handling and better JSON parsing fallbacks
- expand the opportunity card with trade thesis, probability context, and richer Greeks insights while wiring supporting types
- add the missing Vitest global import and pin ESLint so Next.js linting passes

## Testing
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e46d9032fc8325b0e614eb4c7da875