### PR TITLE
Handle missing implied volatility when estimating profit probability

### DIFF
--- a/scripts/fetch_options_data.py
+++ b/scripts/fetch_options_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 from uuid import uuid4
@@ -145,9 +146,11 @@ def estimate_profit_probability(contract: OptionContract) -> Dict[str, object]:
             "explanation": "Insufficient price data to model profitability.",
         }
 
-    sigma = float(contract.implied_volatility or 0.0)
-    if sigma <= 0:
+    sigma_raw = float(contract.implied_volatility or 0.0)
+    if not math.isfinite(sigma_raw) or sigma_raw <= 0:
         sigma = 0.35
+    else:
+        sigma = sigma_raw / 100.0 if sigma_raw > 3 else sigma_raw
 
     expiration = datetime.combine(contract.expiration, datetime.min.time(), tzinfo=timezone.utc)
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- normalize implied volatility values before computing the profit probability model
- add fallbacks for missing or invalid volatility figures to avoid zeroed likelihood outputs

## Testing
- python -m compileall scripts/fetch_options_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e49e1fd39c8325a73c78f461cfebe5