### PR TITLE
Add scanner configuration and expose evaluation counts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,9 +160,15 @@ export default function HomePage() {
       const data = await response.json()
       if (data.success) {
         setOpportunities(data.opportunities || [])
-        // Set total evaluated to 30 (the original scan limit) for now
-        // In the future, this could come from the API response
-        setTotalEvaluated(30)
+        const evaluatedFromApi =
+          typeof data.totalEvaluated === 'number'
+            ? data.totalEvaluated
+            : typeof data.total_evaluated === 'number'
+              ? data.total_evaluated
+              : Array.isArray(data.opportunities)
+                ? data.opportunities.length
+                : 0
+        setTotalEvaluated(evaluatedFromApi)
         setLastUpdate(new Date())
       }
     } catch (error) {

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -30,6 +30,8 @@ watchlists:
     - ASML
     - PLTR
     - ANET
+scanner:
+  limit_per_symbol: 3
 fetcher:
   max_priority_symbols: null
 scoring:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -25,6 +25,8 @@ watchlists:
     - SMCI
     - ASML
     - PLTR
+scanner:
+  limit_per_symbol: 3
 fetcher:
   max_priority_symbols: null
 scoring:

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -23,6 +23,9 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
         "default": ["SPY", "QQQ"],
     },
     "scoring": copy.deepcopy(DEFAULT_SCORER_CONFIG),
+    "scanner": {
+        "limit_per_symbol": 3,
+    },
     "adapter": {
         "provider": "yfinance",
         "settings": {},
@@ -95,6 +98,10 @@ class CacheSettings(BaseModel):
     ttl_seconds: int = 900
 
 
+class ScannerSettings(BaseModel):
+    limit_per_symbol: int = 3
+
+
 class SQLiteSettings(BaseModel):
     path: str = "data/options.db"
     pragmas: Dict[str, Any] = Field(default_factory=dict)
@@ -116,6 +123,7 @@ class AppSettings(BaseModel):
     env: str
     watchlists: Dict[str, List[str]]
     scoring: ScoringSettings
+    scanner: ScannerSettings = Field(default_factory=ScannerSettings)
     adapter: AdapterSettings
     fetcher: FetcherSettings = Field(default_factory=FetcherSettings)
     cache: CacheSettings


### PR DESCRIPTION
## Summary
- add a scanner settings namespace to the configuration loader and environment files
- surface the scanner per-symbol limit in fetch_options_data via settings/CLI and return total_evaluated metadata
- expose the evaluation count through the API response and frontend so the UI reflects scan breadth

## Testing
- python -m compileall scripts/fetch_options_data.py
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e54cf96ab88325a3adcbf64f1c8111