### PR TITLE
Implement rotating scan universe with deep scan support

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -30,8 +30,30 @@ watchlists:
     - ASML
     - PLTR
     - ANET
+  value:
+    - KO
+    - PG
+    - JNJ
+    - MCD
+    - PEP
+    - HD
+  small_caps:
+    - IWM
+    - PLUG
+    - RUN
+    - FVRR
+    - ROKU
+    - UPST
+  short_squeeze:
+    - GME
+    - AMC
+    - BYND
+    - BBBYQ
+    - APRN
 scanner:
   limit_per_symbol: 3
+  batch_size: 25
+  rotation_mode: round_robin
 fetcher:
   max_priority_symbols: null
 scoring:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -25,8 +25,30 @@ watchlists:
     - SMCI
     - ASML
     - PLTR
+  value:
+    - KO
+    - PG
+    - JNJ
+    - MCD
+    - COST
+    - PEP
+  small_caps:
+    - IWM
+    - AFRM
+    - FVRR
+    - UPST
+    - RUN
+    - SOFI
+  short_squeeze:
+    - GME
+    - AMC
+    - BBBYQ
+    - BYND
+    - CVNA
 scanner:
   limit_per_symbol: 3
+  batch_size: 30
+  rotation_mode: random
 fetcher:
   max_priority_symbols: null
 scoring:

--- a/scripts/fetch_options_data.py
+++ b/scripts/fetch_options_data.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import math
 from argparse import ArgumentParser
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Mapping, MutableMapping, Sequence
 from uuid import uuid4
 
+import pandas as pd
+from scipy.stats import norm
+
 from src.config import AppSettings, get_settings
-from src.scanner.service import run_scan
+from src.models.option import OptionContract, OptionGreeks
+from src.scanner.service import run_deep_scan, run_scan
 from src.storage import OptionSnapshot, RunMetadata, SignalSnapshot
 from src.storage.sqlite import SQLiteStorage
 
@@ -19,6 +24,127 @@ def _normalize_symbol_limit(raw_limit: int | None) -> int | None:
     if raw_limit <= 0:
         return None
     return raw_limit
+
+
+def _time_to_expiration(expiration: Any) -> float:
+    expiration_ts = pd.to_datetime(expiration)
+    if pd.isna(expiration_ts):
+        return 0.0
+    if expiration_ts.tzinfo is None:
+        expiration_ts = expiration_ts.tz_localize("UTC")
+    else:
+        expiration_ts = expiration_ts.tz_convert("UTC")
+    now = datetime.now(timezone.utc)
+    delta = max((expiration_ts - pd.Timestamp(now)).total_seconds(), 0.0)
+    return delta / (365.0 * 24 * 60 * 60)
+
+
+def calculate_greeks(row: pd.Series) -> OptionGreeks:
+    """Estimate Black-Scholes greeks with sensible fallbacks."""
+
+    try:
+        stock_price = float(row.get("stockPrice", 0.0) or 0.0)
+        strike = float(row.get("strike", 0.0) or 0.0)
+        option_type = str(row.get("type", "call")).lower()
+        time_to_expiry = _time_to_expiration(row.get("expiration"))
+        if stock_price <= 0 or strike <= 0 or time_to_expiry <= 0:
+            return OptionGreeks()
+
+        implied_vol = float(row.get("impliedVolatility", 0.0) or 0.0)
+        if implied_vol <= 0:
+            implied_vol = 0.35
+        implied_vol = max(0.05, implied_vol)
+
+        rate = 0.015
+        sqrt_t = math.sqrt(time_to_expiry)
+        d1 = (math.log(stock_price / strike) + (rate + 0.5 * implied_vol**2) * time_to_expiry) / (
+            implied_vol * sqrt_t
+        )
+        d2 = d1 - implied_vol * sqrt_t
+
+        if option_type == "put":
+            delta = norm.cdf(d1) - 1.0
+            theta = -(stock_price * norm.pdf(d1) * implied_vol) / (2 * sqrt_t) + rate * strike * math.exp(
+                -rate * time_to_expiry
+            ) * norm.cdf(-d2)
+        else:
+            delta = norm.cdf(d1)
+            theta = -(stock_price * norm.pdf(d1) * implied_vol) / (2 * sqrt_t) - rate * strike * math.exp(
+                -rate * time_to_expiry
+            ) * norm.cdf(d2)
+
+        gamma = norm.pdf(d1) / (stock_price * implied_vol * sqrt_t)
+        vega = stock_price * norm.pdf(d1) * sqrt_t / 100
+
+        return OptionGreeks(
+            delta=float(delta),
+            gamma=float(gamma),
+            theta=float(theta) / 365.0,
+            vega=float(vega),
+        )
+    except Exception:
+        return OptionGreeks()
+
+
+def estimate_profit_probability(contract: OptionContract) -> Dict[str, Any]:
+    """Approximate the probability of reaching the option's breakeven level."""
+
+    iv = float(contract.implied_volatility or 0.0)
+    if iv <= 0:
+        iv = 0.3
+    iv = max(iv, 0.05)
+
+    days = max(contract.days_to_expiration, 1)
+    horizon = days / 365.0
+    sigma = iv * math.sqrt(horizon)
+    if sigma <= 0:
+        sigma = 0.1
+
+    premium = contract.last_price or contract.mid_price
+    if contract.option_type == "call":
+        breakeven_price = contract.strike + premium
+        required_move = max(0.0, (breakeven_price - contract.stock_price) / contract.stock_price)
+        direction = "rise"
+    else:
+        breakeven_price = contract.strike - premium
+        required_move = max(0.0, (contract.stock_price - breakeven_price) / contract.stock_price)
+        direction = "fall"
+
+    z_score = required_move / sigma if sigma > 0 else 10.0
+    probability = 1 - norm.cdf(z_score)
+    probability = max(0.0, min(1.0, float(probability)))
+
+    explanation = (
+        f"The underlying needs to {direction} approximately {required_move * 100:.2f}% to break even. "
+        f"Assuming an implied volatility of {iv:.2%} over {days} days, the success probability is {probability:.1%}."
+    )
+
+    return {
+        "probability": probability,
+        "explanation": explanation,
+        "required_move_pct": required_move * 100,
+    }
+
+
+def summarize_risk_metrics(
+    contract: OptionContract,
+    projected_returns: Mapping[str, float],
+) -> Dict[str, float]:
+    """Summarize upside/downside balance for quick inspection."""
+
+    max_return_multiple = max(float(value) for value in projected_returns.values()) if projected_returns else 0.0
+    max_return_pct = max_return_multiple * 100.0
+    max_loss_pct = 100.0
+    reward_to_risk = max_return_pct / max_loss_pct if max_loss_pct else 0.0
+
+    return {
+        "max_return_pct": float(max_return_pct),
+        "max_loss_pct": max_loss_pct,
+        "reward_to_risk": float(reward_to_risk),
+        "breakeven_price": contract.strike + contract.last_price
+        if contract.option_type == "call"
+        else contract.strike - contract.last_price,
+    }
 
 
 def _build_option_snapshots(symbol: str, contracts: Sequence[Mapping[str, Any]]) -> list[OptionSnapshot]:
@@ -120,6 +246,12 @@ def _build_arg_parser() -> ArgumentParser:
         default=None,
         help="Pretty print JSON output with the provided indentation.",
     )
+    parser.add_argument(
+        "--deep-batches",
+        type=int,
+        default=0,
+        help="Run sequential batches for a deep scan (0 or 1 runs a single batch).",
+    )
     return parser
 
 
@@ -127,8 +259,12 @@ if __name__ == "__main__":
     args = _build_arg_parser().parse_args()
     symbol_limit = _normalize_symbol_limit(args.max_symbols)
 
-    result = run_scan(symbol_limit)
     settings = get_settings()
+    if args.deep_batches and args.deep_batches > 1:
+        result = run_deep_scan(args.deep_batches, symbol_limit)
+    else:
+        result = run_scan(symbol_limit)
+
     _persist_scan_results(settings, result.metadata, result.opportunities)
 
     print(result.to_json(indent=args.json_indent))

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -25,6 +25,8 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     "scoring": copy.deepcopy(DEFAULT_SCORER_CONFIG),
     "scanner": {
         "limit_per_symbol": 3,
+        "batch_size": None,
+        "rotation_mode": "round_robin",
     },
     "adapter": {
         "provider": "yfinance",
@@ -100,6 +102,15 @@ class CacheSettings(BaseModel):
 
 class ScannerSettings(BaseModel):
     limit_per_symbol: int = 3
+    batch_size: Optional[int] = None
+    rotation_mode: str = "round_robin"
+
+    @validator("rotation_mode")
+    def _normalize_rotation_mode(cls, value: str) -> str:  # type: ignore[override]
+        resolved = (value or "round_robin").strip().lower()
+        if resolved not in {"round_robin", "random"}:
+            return "round_robin"
+        return resolved
 
 
 class SQLiteSettings(BaseModel):

--- a/src/scanner/universe.py
+++ b/src/scanner/universe.py
@@ -1,0 +1,190 @@
+"""Helpers for constructing rotating symbol universes for scans."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Tuple
+
+from scripts.bulk_options_fetcher import BulkOptionsFetcher
+from src.config.loader import AppSettings
+
+DEFAULT_STATE_FILE = Path("data/scan_universe_state.json")
+
+
+@dataclass
+class UniverseRotationState:
+    """Serializable container describing the scan universe rotation state."""
+
+    mode: str = "round_robin"
+    position: int = 0
+    order: List[str] = field(default_factory=list)
+    seed: int | None = None
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any] | None) -> "UniverseRotationState":
+        if not payload:
+            return cls()
+        mode = str(payload.get("mode", "round_robin") or "round_robin").lower().strip()
+        position = int(payload.get("position", 0) or 0)
+        order = [str(sym).upper().strip() for sym in payload.get("order", []) if sym]
+        seed_value = payload.get("seed")
+        try:
+            seed = int(seed_value) if seed_value is not None else None
+        except (TypeError, ValueError):
+            seed = None
+        return cls(mode=mode, position=max(position, 0), order=order, seed=seed)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "position": self.position,
+            "order": list(self.order),
+            "seed": self.seed,
+        }
+
+
+def _state_file_from_settings(settings: AppSettings) -> Path:
+    try:
+        sqlite_settings = settings.storage.require_sqlite()
+        sqlite_path = Path(sqlite_settings.path)
+        if sqlite_path.name != ":memory:":
+            base_dir = sqlite_path if sqlite_path.is_dir() else sqlite_path.parent
+            if base_dir.exists():
+                return base_dir / DEFAULT_STATE_FILE.name
+    except Exception:
+        pass
+    return DEFAULT_STATE_FILE
+
+
+def _load_persisted_state(path: Path) -> Mapping[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _persist_state(path: Path, state: Mapping[str, Any]) -> None:
+    if path.name != ":memory:":
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(dict(state), handle, indent=2)
+
+
+def _normalise_universe(symbols: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    cleaned: List[str] = []
+    for symbol in symbols:
+        normalized = str(symbol).upper().strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        cleaned.append(normalized)
+    return cleaned
+
+
+def _prepare_round_robin(state: UniverseRotationState, universe: List[str]) -> UniverseRotationState:
+    if not state.order:
+        state.order = list(universe)
+        state.position = 0
+        return state
+
+    filtered = [symbol for symbol in state.order if symbol in universe]
+    additions = [symbol for symbol in universe if symbol not in filtered]
+    state.order = filtered + additions
+    if state.position >= len(state.order):
+        state.position = 0
+    return state
+
+
+def _prepare_random(state: UniverseRotationState, universe: List[str]) -> UniverseRotationState:
+    rng = random.Random(state.seed)
+    if not state.order or set(state.order) != set(universe):
+        state.order = list(universe)
+        rng.shuffle(state.order)
+        if state.seed is None:
+            state.seed = random.randint(1, 1_000_000)
+            rng = random.Random(state.seed)
+            rng.shuffle(state.order)
+        state.position = 0
+        return state
+
+    if state.position >= len(state.order):
+        state.position = 0
+    return state
+
+
+def _next_batch(order: List[str], position: int, batch_size: int) -> Tuple[List[str], int]:
+    if not order:
+        return [], 0
+
+    if batch_size <= 0:
+        return [], position % len(order)
+
+    total = len(order)
+    start = position % total
+    end = start + batch_size
+    if batch_size >= total:
+        batch = list(order)
+        new_position = end % total
+    elif end <= total:
+        batch = order[start:end]
+        new_position = end % total
+    else:
+        wrap = end % total
+        batch = order[start:] + order[:wrap]
+        new_position = wrap
+    return batch, new_position
+
+
+def build_scan_universe(
+    settings: AppSettings,
+    batch_size: int,
+    rotation_state: Mapping[str, Any] | None,
+) -> Tuple[List[str], Dict[str, Any]]:
+    """Return the next batch of symbols to scan and an updated rotation state."""
+
+    state_path = _state_file_from_settings(settings)
+    persisted_state = _load_persisted_state(state_path)
+    merged_state: MutableMapping[str, Any] = dict(persisted_state)
+    if rotation_state:
+        merged_state.update(rotation_state)
+
+    state = UniverseRotationState.from_mapping(merged_state)
+    if state.mode not in {"round_robin", "random"}:
+        state.mode = "round_robin"
+
+    fetcher = BulkOptionsFetcher(settings)
+    universe = _normalise_universe(fetcher.priority_symbols)
+
+    if not universe:
+        state.order = []
+        state.position = 0
+        _persist_state(state_path, state.to_dict())
+        return [], state.to_dict()
+
+    if state.mode == "random":
+        state = _prepare_random(state, universe)
+    else:
+        state = _prepare_round_robin(state, universe)
+
+    batch, new_position = _next_batch(state.order, state.position, batch_size)
+    state.position = new_position
+
+    if state.mode == "random" and state.order and new_position == 0:
+        rng = random.Random(state.seed or random.randint(1, 1_000_000))
+        rng.shuffle(state.order)
+
+    payload = state.to_dict()
+    _persist_state(state_path, payload)
+
+    return batch, payload
+
+
+__all__ = ["build_scan_universe", "UniverseRotationState"]
+


### PR DESCRIPTION
## Summary
- extend environment configs with new thematic watchlists and scanner rotation settings
- add a universe rotation helper and integrate it into the smart scanner, including deep scan aggregation
- expose analytics helpers and deep scan options in the fetch script while improving caching controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e578e9038c8325b8198ea4bcd61a68