### PR TITLE
Normalize implied volatility decimals in buildOpportunity

### DIFF
--- a/lib/api/ai-analyzer.ts
+++ b/lib/api/ai-analyzer.ts
@@ -156,7 +156,7 @@ function computeGreeks(option: SampleOption, stockPrice: number): OptionGreeks {
   }
 }
 
-function buildOpportunity(
+export function buildOpportunity(
   context: MarketContext,
   option: SampleOption,
 ): { target: ScanTarget; draft: OpportunityScore; key: string } {
@@ -214,7 +214,7 @@ function buildOpportunity(
     ask: Number(ask.toFixed(2)),
     volume: Math.round(option.volume),
     openInterest: Math.round(option.openInterest),
-    impliedVolatility: Number(option.iv.toFixed(4)),
+    impliedVolatility: Number((option.iv / 100).toFixed(4)),
     stockPrice: Number(context.price.toFixed(2)),
   }
 

--- a/tests/unit/ai-analyzer.test.ts
+++ b/tests/unit/ai-analyzer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { buildOpportunity, type MarketContext } from "@/lib/api/ai-analyzer"
+
+describe("buildOpportunity", () => {
+  const baseContext: MarketContext = {
+    symbol: "AAPL",
+    price: 190.25,
+    volume: 1250000,
+    volatility: 1.8,
+    news: [
+      { headline: "AAPL releases new product", sentiment: 0.4 },
+      { headline: "Analysts upgrade outlook", sentiment: 0.2 },
+    ],
+    technicals: {
+      trend: "bullish",
+    },
+  }
+
+  const sampleOption = {
+    type: "call" as const,
+    strike: 195,
+    premium: 4.8,
+    iv: 32.5,
+    volume: 1500,
+    openInterest: 4500,
+    delta: 0.55,
+  }
+
+  it("normalizes implied volatility to a decimal value", () => {
+    const { target, draft } = buildOpportunity(baseContext, sampleOption)
+
+    expect(target.contract.impliedVolatility).toBeCloseTo(0.325, 4)
+    expect(draft.impliedVolatility).toBeCloseTo(0.325, 4)
+  })
+
+  it("keeps the fallback draft aligned with the normalized IV", () => {
+    const { target, draft } = buildOpportunity(baseContext, sampleOption)
+
+    expect(draft.impliedVolatility).toBe(target.contract.impliedVolatility)
+    expect(draft.score).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- normalize the implied volatility emitted by buildOpportunity to its decimal form
- export buildOpportunity and add unit coverage to confirm fallback drafts stay aligned with the normalized value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e57ca104ec832582ad5765f4d0988e