### PR TITLE
Update potential return to per-contract dollars

### DIFF
--- a/components/live-scanner.tsx
+++ b/components/live-scanner.tsx
@@ -7,6 +7,13 @@ import { Button } from "@/components/ui/button"
 import { TrendingUp, TrendingDown, RefreshCw, Zap, Target } from "lucide-react"
 import type { OpportunityScore } from "@/lib/api/ai-analyzer"
 
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
 export function LiveScanner() {
   const [opportunities, setOpportunities] = useState<OpportunityScore[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -145,8 +152,10 @@ export function LiveScanner() {
 
                     <div className="mt-3 grid grid-cols-3 gap-4 text-sm">
                       <div>
-                        <p className="text-muted-foreground">Potential Return</p>
-                        <p className="font-mono font-semibold text-bull">${opp.potentialReturn.toFixed(2)}</p>
+                        <p className="text-muted-foreground">Potential Return (per contract)</p>
+                        <p className="font-mono font-semibold text-bull">
+                          {currencyFormatter.format(opp.potentialReturn)}
+                        </p>
                       </div>
                       <div>
                         <p className="text-muted-foreground">Max Loss</p>

--- a/lib/api/ai-analyzer.ts
+++ b/lib/api/ai-analyzer.ts
@@ -102,7 +102,8 @@ function calculatePotentialReturn(
 ): number {
   const targetPrice = type === "call" ? currentPrice * 1.1 : currentPrice * 0.9
   const intrinsicValue = type === "call" ? Math.max(0, targetPrice - strike) : Math.max(0, strike - targetPrice)
-  return Math.max(0, intrinsicValue - premium)
+  // Return the potential dollar gain for a single contract (100 shares)
+  return Math.max(0, intrinsicValue - premium) * 100
 }
 
 function getNextExpiration(): string {


### PR DESCRIPTION
## Summary
- convert the AI analyzer's potential return calculation to return per-contract dollars
- adjust the live scanner UI to label and format potential return as a per-contract currency value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e58307821083258a00f1b98249355e