### PR TITLE
Clarify directional analysis for put recommendations

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -349,10 +349,25 @@ export default function HomePage() {
     return `${value.toFixed(digits)}%`
   }
 
+  const formatBreakevenRequirement = (opp: Opportunity) => {
+    const move = opp.breakevenMovePercent
+    if (move === null || !Number.isFinite(move)) {
+      return null
+    }
+
+    if (move <= 0) {
+      return 'Already beyond breakeven'
+    }
+
+    const direction = opp.optionType === 'put' ? 'drop' : 'gain'
+    return `Needs ${Math.abs(move).toFixed(1)}% ${direction} to breakeven`
+  }
+
   const getTradeLogic = (opp: Opportunity) => {
     const isCall = opp.optionType === 'call'
     const daysToExp = opp.daysToExpiration
-    const strikeVsPrice = opp.strike / opp.stockPrice
+    const price = Math.max(opp.stockPrice, 0)
+    const strike = opp.strike
     const ivRank = opp.ivRank
     const eventIntel = opp.eventIntel || {}
 
@@ -366,12 +381,25 @@ export default function HomePage() {
     }
     
     // Strike analysis
-    if (strikeVsPrice < 0.95) {
-      logic += `The strike price is ${((1-strikeVsPrice)*100).toFixed(1)}% below the current stock price, making this an in-the-money option with built-in value. `
-    } else if (strikeVsPrice > 1.05) {
-      logic += `The strike price is ${((strikeVsPrice-1)*100).toFixed(1)}% above the current stock price, making this an out-of-the-money option that needs a significant move to be profitable. `
+    const relativeDiff = price > 0 ? Math.abs(price - strike) / price : 0
+    if (relativeDiff < 0.01) {
+      logic += 'The strike price is essentially at-the-money, so even small moves in the underlying can swing this trade. '
+    } else if (isCall) {
+      const diffPct = price > 0 ? ((price - strike) / price) * 100 : 0
+      if (diffPct > 0) {
+        logic += `The strike is ${Math.abs(diffPct).toFixed(1)}% below the stock price, giving this call intrinsic value from the start. `
+      } else {
+        const neededMove = Math.abs(diffPct)
+        logic += `The strike is ${neededMove.toFixed(1)}% above the stock price, so the shares need roughly a ${neededMove.toFixed(1)}% rally to move in-the-money. `
+      }
     } else {
-      logic += `The strike price is very close to the current stock price, making this an at-the-money option that's highly sensitive to price movements. `
+      const diffPct = price > 0 ? ((strike - price) / price) * 100 : 0
+      if (diffPct > 0) {
+        logic += `The strike is ${Math.abs(diffPct).toFixed(1)}% above the stock price, meaning this put already carries intrinsic value from the recent downside move. `
+      } else {
+        const neededDrop = Math.abs(diffPct)
+        logic += `The strike is ${neededDrop.toFixed(1)}% below the stock price, so the underlying would need to drop about ${neededDrop.toFixed(1)}% for the put to move in-the-money. `
+      }
     }
     
     // Time analysis
@@ -1118,11 +1146,10 @@ export default function HomePage() {
                             />
                           </div>
                           <div className="flex items-center justify-between text-xs text-emerald-800 dark:text-emerald-200 mb-3">
-                            {opp.breakevenMovePercent !== null ? (
-                              <span>Needs {opp.breakevenMovePercent.toFixed(1)}% move to breakeven</span>
-                            ) : (
-                              <span>Breakeven move unavailable</span>
-                            )}
+                            {(() => {
+                              const breakevenText = formatBreakevenRequirement(opp)
+                              return breakevenText ? <span>{breakevenText}</span> : <span>Breakeven move unavailable</span>
+                            })()}
                             {opp.breakevenPrice !== null && <span>Breakeven ${opp.breakevenPrice.toFixed(2)}</span>}
                           </div>
                           <p className="text-sm text-emerald-900 dark:text-emerald-100 leading-relaxed">
@@ -1187,14 +1214,20 @@ export default function HomePage() {
                                     <span className="text-sm font-medium text-slate-600 dark:text-slate-400">
                                       {scenarioItem.move || `${scenarioItem.return.toFixed(0)}%`} Stock Move
                                     </span>
-                                    <span className="text-xs font-semibold text-emerald-600">
-                                      +{scenarioItem.return.toFixed(1)}%
+                                    <span
+                                      className={`text-xs font-semibold ${scenarioItem.return >= 0 ? 'text-emerald-600' : 'text-red-600'}`}
+                                    >
+                                      {scenarioItem.return >= 0
+                                        ? `+${scenarioItem.return.toFixed(1)}%`
+                                        : `${scenarioItem.return.toFixed(1)}%`}
                                     </span>
                                   </div>
                                   <div className="space-y-1">
                                     <div className="flex justify-between text-sm">
                                       <span className="text-slate-600 dark:text-slate-400">Profit:</span>
-                                      <span className="font-semibold text-emerald-600">
+                                      <span
+                                        className={`font-semibold ${scenarioItem.profit >= 0 ? 'text-emerald-600' : 'text-red-600'}`}
+                                      >
                                         {formatCurrency(scenarioItem.profit)}
                                       </span>
                                     </div>
@@ -1255,11 +1288,12 @@ export default function HomePage() {
                         <div className="text-lg font-semibold text-slate-900 dark:text-white">
                           {opp.probabilityOfProfit !== null ? `${opp.probabilityOfProfit.toFixed(1)}%` : '—'}
                         </div>
-                        {opp.breakevenMovePercent !== null && (
-                          <div className="text-xs text-slate-500 dark:text-slate-400">
-                            Needs {opp.breakevenMovePercent.toFixed(1)}% move
-                          </div>
-                        )}
+                        {(() => {
+                          const breakevenText = formatBreakevenRequirement(opp)
+                          return breakevenText ? (
+                            <div className="text-xs text-slate-500 dark:text-slate-400">{breakevenText}</div>
+                          ) : null
+                        })()}
                       </div>
                       <div className="bg-slate-50 dark:bg-slate-800 rounded-2xl p-4">
                         <div className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Reward-to-Risk</div>


### PR DESCRIPTION
## Summary
- Align the scanner's breakeven reasoning and ROI scenario modeling with the actual price direction required for put contracts
- Update the trade-logic copy and breakeven messaging in the UI so puts explicitly call out the need for a downside move and negative scenarios render with warning colors
- Normalize per-contract scenario summaries so stock move labels and profit figures reflect signed moves instead of always showing gains

## Testing
- npm run lint
- pytest *(fails: requires external data access and environment-specific cache settings)*

------
https://chatgpt.com/codex/tasks/task_e_68e5de2a60f083259e3543e0d2341d34