### PR TITLE
Update default redirect paths from /portfolio to /

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/portfolio'
+  const next = searchParams.get('next') ?? '/'
 
   if (code) {
     const supabase = await createClient()

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -64,7 +64,7 @@ export default function LoginPage() {
           password,
         })
         if (error) throw error
-        router.push('/portfolio')
+        router.push('/')
         router.refresh()
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
Updated the default redirect destination after authentication from `/portfolio` to `/` (home page) in both the OAuth callback handler and login form submission.

## Changes
- **Auth callback route** (`app/auth/callback/route.ts`): Changed default redirect from `/portfolio` to `/` when no explicit `next` parameter is provided
- **Login page** (`app/auth/login/page.tsx`): Changed post-login redirect from `/portfolio` to `/` after successful authentication

## Details
These changes ensure users are redirected to the home page instead of the portfolio page after logging in or completing OAuth authentication. This provides a more standard user experience where the home page serves as the primary landing destination post-authentication.